### PR TITLE
Typo in connection string regex

### DIFF
--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -106,7 +106,7 @@ has sqlite =>;
 has collections =>;
 
 sub new( $class, $url, $collections ) {
-    my ( $connect ) = ( defined $url && length $url ) ? $url =~ m{^[^:]+://(.+)$} : undef;
+    my ( $connect ) = ( defined $url && length $url ) ? $url =~ m{^[^:]+:(.+)$} : undef;
     my %vars = (
         sqlite => Mojo::SQLite->new( defined $connect ? "sqlite:$connect" : () ),
         collections => $collections,

--- a/t/backend/sqlite.t
+++ b/t/backend/sqlite.t
@@ -75,6 +75,7 @@ subtest 'new' => sub {
     is_deeply $be->collections, $collections;
 };
 
+# Override sqlite attribute with reference to instantiated db object from above
 $be->sqlite( $sqlite );
 
 sub insert_item( $coll, %item ) {


### PR DESCRIPTION
Somehow in editing the correct removal of `//` from the connection string regex was undone. We now merely pass along anything after the `:`.