### PR TITLE
OpenAPI no array

### DIFF
--- a/eg/todo-app/myapp.pl
+++ b/eg/todo-app/myapp.pl
@@ -142,9 +142,6 @@ helper build_todo_log => sub {
     }
 };
 
-# Documentation browser under "/perldoc"
-plugin 'PODRenderer';
-
 get '/:date' => { date => '' }, sub {
     my ( $c ) = @_;
     my $dt = $c->stash( 'date' ) ? _parse_ymd( $c->stash( 'date' ) ) : DateTime->today;

--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -457,10 +457,10 @@ sub _build_openapi_spec {
         my $id_field = $collection->{ 'x-id-field' } // 'id';
         my %props = %{ $collection->{ properties } };
 
-        $definitions{ $name . 'Item' } = $collection;
+        $definitions{ $name } = $collection;
         $definitions{ $name . 'Array' } = {
             type => 'array',
-            items => { '$ref' => "#/definitions/${name}Item" },
+            items => { '$ref' => "#/definitions/${name}" },
         };
 
         for my $prop ( keys %props ) {
@@ -516,7 +516,7 @@ sub _build_openapi_spec {
                                 items => {
                                     type => 'array',
                                     description => 'This page of items',
-                                    items => { '$ref' => "#/definitions/${name}Item" },
+                                    items => { '$ref' => "#/definitions/${name}" },
                                 },
                             },
                         },
@@ -538,13 +538,13 @@ sub _build_openapi_spec {
                         name => "newItem",
                         in => "body",
                         required => true,
-                        schema => { '$ref' => "#/definitions/${name}Item" },
+                        schema => { '$ref' => "#/definitions/${name}" },
                     },
                 ],
                 responses => {
                     201 => {
                         description => "Entry was created",
-                        schema => { '$ref' => "#/definitions/${name}Item/properties/${id_field}" },
+                        schema => { '$ref' => "#/definitions/${name}/properties/${id_field}" },
                     },
                     400 => {
                         description => "New entry contains errors",
@@ -580,7 +580,7 @@ sub _build_openapi_spec {
                 responses => {
                     200 => {
                         description => "Item details",
-                        schema => { '$ref' => "#/definitions/${name}Item" },
+                        schema => { '$ref' => "#/definitions/${name}" },
                     },
                     404 => {
                         description => "The item was not found",
@@ -606,13 +606,13 @@ sub _build_openapi_spec {
                         name => "newItem",
                         in => "body",
                         required => true,
-                        schema => { '$ref' => "#/definitions/${name}Item" },
+                        schema => { '$ref' => "#/definitions/${name}" },
                     }
                 ],
                 responses => {
                     200 => {
                         description => "Item was updated",
-                        schema => { '$ref' => "#/definitions/${name}Item" },
+                        schema => { '$ref' => "#/definitions/${name}" },
                     },
                     404 => {
                         description => "The item was not found",

--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -458,10 +458,6 @@ sub _build_openapi_spec {
         my %props = %{ $collection->{ properties } };
 
         $definitions{ $name } = $collection;
-        $definitions{ $name . 'Array' } = {
-            type => 'array',
-            items => { '$ref' => "#/definitions/${name}" },
-        };
 
         for my $prop ( keys %props ) {
             $props{ $prop }{ type } ||= 'string';

--- a/lib/Mojolicious/Plugin/Yancy/resources/public/yancy/app.js
+++ b/lib/Mojolicious/Plugin/Yancy/resources/public/yancy/app.js
@@ -339,7 +339,7 @@ var app = new Vue({
                 collectionName = pathParts[1];
 
                 // Skip hidden collections
-                if ( spec.definitions[ collectionName + 'Item' ]['x-hidden'] ) {
+                if ( spec.definitions[ collectionName ]['x-hidden'] ) {
                     continue;
                 }
 
@@ -359,13 +359,13 @@ var app = new Vue({
                     if ( pathObj.get ) {
                         collection.operations["list"] = {
                             url: [ spec.basePath, pathKey ].join(''),
-                            schema: spec.definitions[ collectionName + 'Item' ]
+                            schema: spec.definitions[ collectionName ]
                         };
                     }
                     if ( pathObj.post ) {
                         collection.operations["add"] = {
                             url: [ spec.basePath, pathKey ].join(''),
-                            schema: spec.definitions[ collectionName + 'Item' ]
+                            schema: spec.definitions[ collectionName ]
                         };
                     }
                 }
@@ -374,19 +374,19 @@ var app = new Vue({
                     if ( pathObj.get ) {
                         collection.operations["get"] = {
                             url: [ spec.basePath, pathKey ].join(''),
-                            schema: spec.definitions[ collectionName + 'Item' ]
+                            schema: spec.definitions[ collectionName ]
                         };
                     }
                     if ( pathObj.put ) {
                         collection.operations["set"] = {
                             url: [ spec.basePath, pathKey ].join(''),
-                            schema: spec.definitions[ collectionName + 'Item' ]
+                            schema: spec.definitions[ collectionName ]
                         };
                     }
                     if ( pathObj.delete ) {
                         collection.operations["delete"] = {
                             url: [ spec.basePath, pathKey ].join(''),
-                            schema: spec.definitions[ collectionName + 'Item' ]
+                            schema: spec.definitions[ collectionName ]
                         };
                     }
                 }

--- a/t/api.t
+++ b/t/api.t
@@ -145,7 +145,7 @@ sub test_api {
         $t->get_ok( '/yancy/api' )
           ->status_is( 200 )
           ->content_type_like( qr{^application/json} )
-          ->json_is( '/definitions/peopleItem' => {
+          ->json_is( '/definitions/people' => {
             type => 'object',
             required => [qw( name )],
             properties => {
@@ -174,7 +174,7 @@ sub test_api {
             },
           } )
 
-          ->json_is( '/definitions/userItem' => {
+          ->json_is( '/definitions/user' => {
             type => 'object',
             'x-id-field' => 'username',
             'x-list-columns' => [qw( username email )],
@@ -243,7 +243,7 @@ sub test_api {
             $t->get_ok( '/yancy/api' )
               ->status_is( 200 )
               ->content_type_like( qr{^application/json} )
-              ->json_is( '/definitions/peopleItem' => {
+              ->json_is( '/definitions/people' => {
                 type => 'object',
                 required => [qw( name )],
                 properties => {
@@ -269,9 +269,9 @@ sub test_api {
                     },
                 },
               } )
-              ->or( sub { diag explain shift->tx->res->json( '/definitions/peopleItem' ) } )
+              ->or( sub { diag explain shift->tx->res->json( '/definitions/people' ) } )
 
-              ->json_is( '/definitions/userItem' => {
+              ->json_is( '/definitions/user' => {
                 type => 'object',
                 required => [qw( username email password )],
                 properties => {
@@ -302,7 +302,7 @@ sub test_api {
                     },
                 },
               } )
-              ->or( sub { diag explain shift->tx->res->json( '/definitions/userItem' ) } )
+              ->or( sub { diag explain shift->tx->res->json( '/definitions/user' ) } )
 
         };
 
@@ -315,8 +315,8 @@ sub test_api {
             $t->get_ok( '/yancy/api' )
               ->status_is( 200 )
               ->content_type_like( qr{^application/json} )
-              ->json_has( '/definitions/peopleItem', 'people read from schema' )
-              ->json_hasnt( '/definitions/userItem', 'user ignored from schema' )
+              ->json_has( '/definitions/people', 'people read from schema' )
+              ->json_hasnt( '/definitions/user', 'user ignored from schema' )
               ;
         };
 

--- a/t/share/config.pl
+++ b/t/share/config.pl
@@ -1,6 +1,5 @@
 {
     plugins => [
-        [ 'PODRenderer' ],
         [ 'Test' => { args => "one" } ],
     ],
     backend => 'test://localhost/',

--- a/t/standalone.t
+++ b/t/standalone.t
@@ -97,7 +97,6 @@ my ( $backend_url, $backend, %items ) = init_backend(
 $ENV{MOJO_HOME} = path( $Bin, 'share' );
 my $t = Test::Mojo->new( 'Yancy', {
     plugins => [
-        [ 'PODRenderer' ],
         [ 'Test', { args => "one" } ],
     ],
     backend => $backend_url,
@@ -160,9 +159,7 @@ subtest 'template handler' => sub {
 };
 
 subtest 'plugins' => sub {
-    $t->get_ok( '/perldoc' )
-      ->status_is( 200, 'PODRenderer returns 200 OK' )
-      ->get_ok( '/test' )
+    $t->get_ok( '/test' )
       ->status_is( 200 )
       ->json_is( [ { args => "one" } ] )
       ;


### PR DESCRIPTION
Turns out that while a definition was *created* for the `*Array`, it was not used and instead the `{items:*}` thing was used. I have simplified the definition-name as discussed, to remove `Item`. I also zapped the `PODRenderer` plugin, since Mojolicious now reports that's deprecated.