### PR TITLE
Fix tests

### DIFF
--- a/t/api.t
+++ b/t/api.t
@@ -126,7 +126,8 @@ subtest 'declared collections' => \&test_api,
     Test::Mojo->new( 'Yancy', {
         backend => $backend_url,
         collections => $collections,
-    } );
+    } ),
+    '/yancy/api';
 
 ( $backend_url, $backend, %items ) = init_backend( $collections, %data );
 subtest 'read_schema collections' => \&test_api,
@@ -134,15 +135,16 @@ subtest 'read_schema collections' => \&test_api,
         backend => $backend_url,
         collections => $collections,
         read_schema => 1,
-    } );
+    } ),
+    '/yancy/api';
 
 done_testing;
 
 sub test_api {
-    my ( $t ) = @_;
+    my ( $t, $api_path ) = @_;
 
-    subtest 'fetch generated OpenAPI spec' => sub {
-        $t->get_ok( '/yancy/api' )
+    subtest 'fetch generated OpenAPI spec '.$api_path => sub {
+        $t->get_ok( $api_path )
           ->status_is( 200 )
           ->content_type_like( qr{^application/json} )
           ->json_is( '/definitions/people' => {
@@ -322,8 +324,8 @@ sub test_api {
 
     };
 
-    subtest 'fetch list' => sub {
-        $t->get_ok( '/yancy/api/people' )
+    subtest 'fetch list '.$api_path => sub {
+        $t->get_ok( $api_path . '/people' )
           ->status_is( 200 )
           ->json_is( {
             items => [
@@ -351,7 +353,7 @@ sub test_api {
           } );
 
         subtest 'limit/offset' => sub {
-            $t->get_ok( '/yancy/api/people?$limit=1' )
+            $t->get_ok( $api_path . '/people?$limit=1' )
               ->status_is( 200 )
               ->json_is( {
                 items => [
@@ -366,7 +368,7 @@ sub test_api {
                 total => 3,
               } );
 
-            $t->get_ok( '/yancy/api/people?$offset=1' )
+            $t->get_ok( $api_path . '/people?$offset=1' )
               ->status_is( 200 )
               ->json_is( {
                 items => [
@@ -390,7 +392,7 @@ sub test_api {
 
         subtest 'order_by' => sub {
 
-            $t->get_ok( '/yancy/api/people?$order_by=asc:name' )
+            $t->get_ok( $api_path . '/people?$order_by=asc:name' )
               ->status_is( 200 )
               ->json_is( {
                 items => [
@@ -417,7 +419,7 @@ sub test_api {
                 total => 3,
               } );
 
-            $t->get_ok( '/yancy/api/people?$order_by=desc:name' )
+            $t->get_ok( $api_path . '/people?$order_by=desc:name' )
               ->status_is( 200 )
               ->json_is( {
                 items => [
@@ -447,7 +449,7 @@ sub test_api {
         };
 
         subtest 'filter' => sub {
-            $t->get_ok( '/yancy/api/people?name=Doug*' )
+            $t->get_ok( $api_path . '/people?name=Doug*' )
               ->status_is( 200 )
               ->json_is( {
                 items => [
@@ -462,7 +464,7 @@ sub test_api {
                 total => 1,
               } );
 
-            $t->get_ok( '/yancy/api/people?name=*l' )
+            $t->get_ok( $api_path . '/people?name=*l' )
               ->status_is( 200 )
               ->json_is( {
                 items => [
@@ -477,7 +479,7 @@ sub test_api {
                 total => 1,
               } );
 
-            $t->get_ok( '/yancy/api/people?name=er' )
+            $t->get_ok( $api_path . '/people?name=er' )
               ->status_is( 200 )
               ->json_is( {
                 items => [
@@ -501,8 +503,8 @@ sub test_api {
 
     };
 
-    subtest 'fetch one' => sub {
-        $t->get_ok( '/yancy/api/people/' . $items{people}[0]{id} )
+    subtest 'fetch one '.$api_path => sub {
+        $t->get_ok( $api_path . '/people/' . $items{people}[0]{id} )
           ->status_is( 200 )
           ->json_is(
             {
@@ -513,7 +515,7 @@ sub test_api {
                 contact => 1,
             },
           );
-        $t->get_ok( '/yancy/api/people/' . $items{people}[2]{id} )
+        $t->get_ok( $api_path . '/people/' . $items{people}[2]{id} )
           ->status_is( 200 )
           ->json_is(
             {
@@ -522,7 +524,7 @@ sub test_api {
                 contact => 0,
             },
           );
-        $t->get_ok( '/yancy/api/user/doug' )
+        $t->get_ok( $api_path . '/user/doug' )
           ->status_is( 200 )
           ->json_is(
             {
@@ -536,7 +538,7 @@ sub test_api {
           );
 
         subtest 'fetch one with / in ID' => sub {
-            $t->get_ok( '/yancy/api/user/joe/' )
+            $t->get_ok( $api_path . '/user/joe/' )
               ->status_is( 200 )
               ->json_is(
                 {
@@ -551,7 +553,7 @@ sub test_api {
         };
     };
 
-    subtest 'set one' => sub {
+    subtest 'set one '.$api_path => sub {
         my $new_person = {
             name => 'Foo',
             email => 'doug@example.com',
@@ -559,7 +561,7 @@ sub test_api {
             age => 35,
             contact => 1,
         };
-        $t->put_ok( '/yancy/api/people/' . $items{people}[0]{id} => json => $new_person )
+        $t->put_ok( $api_path . '/people/' . $items{people}[0]{id} => json => $new_person )
           ->status_is( 200 )
           ->json_is( $new_person );
         is_deeply $backend->get( people => $items{people}[0]{id} ), $new_person;
@@ -571,7 +573,7 @@ sub test_api {
             access => 'user',
             age => 35,
         };
-        $t->put_ok( '/yancy/api/user/doug' => json => $new_user )
+        $t->put_ok( $api_path . '/user/doug' => json => $new_user )
           ->status_is( 200 );
         $t->json_is( { %$new_user, id => $items{user}[0]{id} } );
         is_deeply $backend->get( user => 'doug' ),
@@ -585,7 +587,7 @@ sub test_api {
                 access => 'user',
                 age => 35,
             };
-            $t->put_ok( '/yancy/api/user/doug' => json => $new_user )
+            $t->put_ok( $api_path . '/user/doug' => json => $new_user )
               ->status_is( 200 );
             $t->json_is( { %$new_user, id => $items{user}[0]{id} } );
             is_deeply $backend->get( user => 'douglas' ),
@@ -595,7 +597,7 @@ sub test_api {
 
     };
 
-    subtest 'add one' => sub {
+    subtest 'add one '.$api_path => sub {
         my $new_person = {
             name => 'Flexo',
             email => undef,
@@ -603,7 +605,7 @@ sub test_api {
             age => 3,
             contact => 0,
         };
-        $t->post_ok( '/yancy/api/people' => json => $new_person )
+        $t->post_ok( $api_path . '/people' => json => $new_person )
           ->status_is( 201 )
           ->json_is( $new_person->{id} )
           ;
@@ -615,7 +617,7 @@ sub test_api {
             password => 'ignore',
             access => 'user',
         };
-        $t->post_ok( '/yancy/api/user' => json => $new_user )
+        $t->post_ok( $api_path . '/user' => json => $new_user )
           ->status_is( 201 )
           ->json_is( 'flexo' );
         my $got = $backend->get( user => 'flexo' );
@@ -626,13 +628,13 @@ sub test_api {
         like $got->{id}, qr/^\d+$/, 'id is a number';
     };
 
-    subtest 'delete one' => sub {
-        $t->delete_ok( '/yancy/api/people/4' )
+    subtest 'delete one '.$api_path => sub {
+        $t->delete_ok( $api_path . '/people/4' )
           ->status_is( 204 )
           ;
         ok !$backend->get( people => 4 ), 'person 4 not exists';
 
-        $t->delete_ok( '/yancy/api/user/flexo' )
+        $t->delete_ok( $api_path . '/user/flexo' )
           ->status_is( 204 )
           ;
         ok !$backend->get( user => 'flexo' ), 'flexo not exists';

--- a/t/helpers.t
+++ b/t/helpers.t
@@ -387,7 +387,7 @@ subtest 'schema' => sub {
         });
         my $collection_keys = [ sort keys %{ $t->app->yancy->schema } ];
         is_deeply $collection_keys,
-            [qw{ mojo_migrations people user }],
+            [qw{ blog mojo_migrations people user }],
             'schema() gets correct collections from read_schema'
             or diag explain $collection_keys;
     };

--- a/t/helpers.t
+++ b/t/helpers.t
@@ -385,9 +385,11 @@ subtest 'schema' => sub {
             backend => $backend_url,
             read_schema => 1,
         });
-        is_deeply [ sort keys %{ $t->app->yancy->schema }],
+        my $collection_keys = [ sort keys %{ $t->app->yancy->schema } ];
+        is_deeply $collection_keys,
             [qw{ mojo_migrations people user }],
-            'schema() gets correct collections from read_schema';
+            'schema() gets correct collections from read_schema'
+            or diag explain $collection_keys;
     };
 
     subtest 'add schema' => sub {

--- a/t/lib/Local/Test.pm
+++ b/t/lib/Local/Test.pm
@@ -80,6 +80,36 @@ END {
 # This is only for when the Test backend is being used and is
 # ignored when TEST_YANCY_BACKEND is set to something else
 %Yancy::Backend::Test::SCHEMA = (
+    blog => {
+        type => 'object',
+        required => [qw( id )],
+        properties => {
+            id => {
+              'x-order' => 1,
+              type => 'integer',
+            },
+            user_id => {
+              'x-order' => 2,
+              type => [ 'integer', 'null' ],
+            },
+            title => {
+              'x-order' => 3,
+              type => [ 'string', 'null' ],
+            },
+            slug => {
+              'x-order' => 4,
+              type => [ 'string', 'null' ],
+            },
+            markdown => {
+              'x-order' => 5,
+              type => [ 'string', 'null' ],
+            },
+            html => {
+              type => [ 'string', 'null' ],
+              'x-order' => 6,
+            },
+        },
+    },
     mojo_migrations => {
         type => 'object',
         required => [qw( name version )],


### PR DESCRIPTION
Travis is currently failing, because the new `schema` helper revealed that `Local::Test`'s schema doesn't have `blog`, while all the `*_BACKEND` schemas do. This PR harmonises those. It also includes a couple of test improvements I stumbled across while working on the "config route" stuff.