### PR TITLE
Filters enhancements

### DIFF
--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -1214,9 +1214,9 @@ sub _helper_filter_apply {
             my $sub = $filters->{ $filter };
             die "Unknown filter: $filter (collection: $coll_name, field: $key)"
                 unless $sub;
-            $item->{ $key } = $sub->(
+            $item = { %$item, $key => $sub->(
                 $key, $item->{ $key }, $coll->{properties}{ $key }, @params
-            );
+            ) };
         }
     }
     if ( my $coll_filters = $coll->{'x-filter'} ) {

--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -391,6 +391,23 @@ executed in that order. E.g.:
         },
     }
 
+You can also configure filters on OpenAPI operations' outputs, this time
+with the key C<x-filter-output>. Again, the config passed will be an empty
+hash. The filter can be applied to either or both of the path, or the
+individual operation, and will be executed in that order. E.g.:
+
+    # mysite.conf
+    {
+        openapi => {
+            paths => {
+                "/people" => {
+                    'x-filter-output' => [ 'timestamp' ],
+                    # ...
+                },
+            }
+        },
+    }
+
 =head3 Supplied filters
 
 These filters are always installed.
@@ -724,6 +741,11 @@ sub _openapi_spec_add_mojo {
                 @{ $op_spec->{ 'x-filter' } || [] },
             );
             $mojo->{filters} = \@filters if @filters;
+            my @filters_out = (
+                @{ $pathspec->{ 'x-filter-output' } || [] },
+                @{ $op_spec->{ 'x-filter-output' } || [] },
+            );
+            $mojo->{filters_out} = \@filters_out if @filters_out;
             $op_spec->{ 'x-mojo-to' } = $mojo;
         }
     }

--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -441,6 +441,7 @@ has _filters => sub { {} };
 
 sub register {
     my ( $self, $app, $config ) = @_;
+    $config = { %$config }; # avoid mutating input
     my $route = $config->{route} // $app->routes->any( '/yancy' );
     $route->to( return_to => $config->{return_to} // '/' );
     $config->{api_controller} //= 'Yancy::API';
@@ -489,6 +490,7 @@ sub register {
     my $spec;
     if ( $config->{openapi} ) {
         $spec = $config->{openapi};
+        $config->{collections} = $spec->{definitions}; # for yancy.backend etc
     }
     else {
         # Merge configuration

--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -435,6 +435,11 @@ The property-level filters will run before any collection-level filter,
 so that collection-level filters can take advantage of any values set by
 the inner filters.
 
+=head2 yancy.filters
+
+Returns a hash-ref of all configured helpers, mapping the names to
+the code-refs.
+
 =head2 yancy.schema
 
     my $schema = $c->yancy->schema( $name );
@@ -553,6 +558,9 @@ sub register {
     }
     $app->helper( 'yancy.filter.add' => curry( \&_helper_filter_add, $self ) );
     $app->helper( 'yancy.filter.apply' => curry( \&_helper_filter_apply, $self ) );
+    $app->helper( 'yancy.filters' => sub {
+        state $filters = $self->_filters;
+    } );
 
     # Routes
     $route->get( '/' )->name( 'yancy.index' )

--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -494,6 +494,22 @@ The utility of this comes from being able to expressively translate to
 and from a simple database structure to a situation where simple values
 or JSON objects need to be wrapped in objects one or two deep.
 
+=head4 yancy.unwrap
+
+This is the converse of the above. The configured parameters are a
+list of strings. For each one, the original value (a hash-ref) will be
+"unwrapped" by looking in the given hash and extracting the value whose
+key is that string. E.g. with this config:
+
+    'x-filter' => [
+        [ 'yancy.unwrap' => qw(login user) ],
+    ],
+
+This will achieve the reverse of the transformation given in
+L</yancy.wrap> above. Note that obviously the order of arguments is
+inverted, since this operates outside-inward, while C<yancy.wrap>
+operates inside-outward.
+
 =head2 yancy.filter.apply
 
     my $filtered_data = $c->yancy->filter->apply( $collection, $item_data );
@@ -626,6 +642,11 @@ sub register {
     $self->_helper_filter_add( undef, 'yancy.wrap' => sub {
         my ( $field_name, $field_value, $field_conf, @params ) = @_;
         $field_value = { $_ => $field_value } for @params;
+        $field_value;
+    } );
+    $self->_helper_filter_add( undef, 'yancy.unwrap' => sub {
+        my ( $field_name, $field_value, $field_conf, @params ) = @_;
+        $field_value = $field_value->{$_} for @params;
         $field_value;
     } );
     for my $name ( keys %{ $config->{filters} } ) {

--- a/lib/Yancy/Controller/Yancy/API.pm
+++ b/lib/Yancy/Controller/Yancy/API.pm
@@ -195,7 +195,7 @@ sub _delete_null_values {
     for my $item ( @_ ) {
         delete $item->{ $_ } for grep !defined $item->{ $_ }, keys %$item;
     }
-    return @_;
+    return wantarray ? @_ : $_[0];
 }
 
 #=sub _apply_op_filters

--- a/lib/Yancy/Controller/Yancy/API.pm
+++ b/lib/Yancy/Controller/Yancy/API.pm
@@ -48,6 +48,10 @@ use Mojo::Base 'Mojolicious::Controller';
 List the items in a collection. The collection name should be in the
 stash key C<collection>.
 
+Each returned item will be filtered by filters conforming with
+L<Mojolicious::Plugin::Yancy/yancy.filter.add> that are passed in the
+array-ref in stash key C<filters_out>.
+
 C<$limit>, C<$offset>, and C<$order_by> may be provided as query parameters.
 
 =cut
@@ -78,8 +82,12 @@ sub list_items {
         $filter{ $key } = { -like => $value };
     }
 
-    my $res = $c->yancy->backend->list( $c->stash( 'collection' ), \%filter, \%opt );
+    my $coll = $c->stash( 'collection' );
+    my $res = $c->yancy->backend->list( $coll, \%filter, \%opt );
     _delete_null_values( @{ $res->{items} } );
+    $res->{items} = [
+        map _apply_op_filters( $coll, $_, $c->stash( 'filters_out' ), $c->yancy->filters ), @{ $res->{items} }
+    ] if $c->stash( 'filters_out' );
 
     return $c->render(
         status => 200,
@@ -98,6 +106,8 @@ filters conforming with L<Mojolicious::Plugin::Yancy/yancy.filter.add>
 that are passed in the array-ref in stash key C<filters>, after the
 collection and property filters have been applied.
 
+The return value is filtered like each result is in L</list_items>.
+
 =cut
 
 sub add_item {
@@ -107,9 +117,12 @@ sub add_item {
     my $item = $c->yancy->filter->apply( $coll, $c->validation->param( 'newItem' ) );
     $item = _apply_op_filters( $coll, $item, $c->stash( 'filters' ), $c->yancy->filters )
         if $c->stash( 'filters' );
+    my $res = $c->yancy->backend->create( $coll, $item );
+    $res = _apply_op_filters( $coll, $res, $c->stash( 'filters_out' ), $c->yancy->filters )
+        if $c->stash( 'filters_out' );
     return $c->render(
         status => 201,
-        openapi => $c->yancy->backend->create( $coll, $item ),
+        openapi => $res,
     );
 }
 
@@ -121,6 +134,8 @@ stash key C<collection>.
 The item's ID field-name is in the stash key C<id_field>. The ID itself
 is extracted from the OpenAPI input, under a parameter of that name.
 
+The return value is filtered like each result is in L</list_items>.
+
 =cut
 
 sub get_item {
@@ -128,9 +143,13 @@ sub get_item {
     return unless $c->openapi->valid_input;
     my $args = $c->validation->output;
     my $id = $args->{ $c->stash( 'id_field' ) };
+    my $coll = $c->stash( 'collection' );
+    my $res = _delete_null_values( $c->yancy->backend->get( $coll, $id ) );
+    $res = _apply_op_filters( $coll, $res, $c->stash( 'filters_out' ), $c->yancy->filters )
+        if $c->stash( 'filters_out' );
     return $c->render(
         status => 200,
-        openapi => _delete_null_values( $c->yancy->backend->get( $c->stash( 'collection' ), $id ) ),
+        openapi => $res,
     );
 }
 
@@ -142,6 +161,8 @@ key C<collection>.
 The item to be updated is determined as with L</get_item>, and what to
 update it with is determined as with L</add_item>.
 
+The return value is filtered like each result is in L</list_items>.
+
 =cut
 
 sub set_item {
@@ -151,16 +172,19 @@ sub set_item {
     my $id = $args->{ $c->stash( 'id_field' ) };
     my $coll = $c->stash( 'collection' );
     my $item = $c->yancy->filter->apply( $coll, $args->{ newItem } );
-    $item = _apply_op_filters( $c->stash( 'collection' ), $item, $c->stash( 'filters' ), $c->yancy->filters )
+    $item = _apply_op_filters( $coll, $item, $c->stash( 'filters' ), $c->yancy->filters )
         if $c->stash( 'filters' );
     $c->yancy->backend->set( $coll, $id, $item );
 
     # ID field may have changed
     $id = $item->{ $c->stash( 'id_field' ) } || $id;
 
+    my $res = _delete_null_values( $c->yancy->backend->get( $coll, $id ) );
+    $res = _apply_op_filters( $coll, $res, $c->stash( 'filters_out' ), $c->yancy->filters )
+        if $c->stash( 'filters_out' );
     return $c->render(
         status => 200,
-        openapi => _delete_null_values( $c->yancy->backend->get( $coll, $id ) ),
+        openapi => $res,
     );
 }
 

--- a/lib/Yancy/Controller/Yancy/API.pm
+++ b/lib/Yancy/Controller/Yancy/API.pm
@@ -193,9 +193,7 @@ sub delete_item {
 # confusing to understand what the problem is
 sub _delete_null_values {
     for my $item ( @_ ) {
-        for my $key ( grep { !defined $item->{ $_ } } keys %$item ) {
-            delete $item->{ $key };
-        }
+        delete $item->{ $_ } for grep !defined $item->{ $_ }, keys %$item;
     }
     return @_;
 }

--- a/lib/Yancy/Help/Config.pod
+++ b/lib/Yancy/Help/Config.pod
@@ -363,6 +363,10 @@ L<Mojolicious::Plugin::Yancy>. See
 L<Mojolicious::Plugin::Yancy/yancy.filter.add> for how to create
 a filter in your app.
 
+Instead of a filter name, you can provide an array. The first member
+will be the name, and any further members will be passed to the filter
+code-ref as parameters after the mandatory three.
+
 =item x-view-url
 
 A URL to view the collection in the application. Will be shown as a button
@@ -416,6 +420,10 @@ Filters are added by plugins or during configuration of
 L<Mojolicious::Plugin::Yancy>. See
 L<Mojolicious::Plugin::Yancy/yancy.filter.add> for how to create a filter
 in your app.
+
+Instead of a filter name, you can provide an array. The first member
+will be the name, and any further members will be passed to the filter
+code-ref as parameters after the mandatory three.
 
 =back
 

--- a/t/filter.t
+++ b/t/filter.t
@@ -154,6 +154,21 @@ subtest 'run wrap filter' => sub {
     is $filtered_user->{password}, 'unfiltered', 'no filter, no change';
 };
 
+subtest 'run unwrap filter' => sub {
+    local $t->app->yancy->config->{collections}{user}{properties}{email}{'x-filter'} = [
+        [ 'yancy.wrap', qw(hi there) ],
+        [ 'yancy.unwrap', qw(there hi) ],
+    ];
+    my $email = 'filter@example.com';
+    my $user = {
+        username => 'unfiltered',
+        email => $email,
+        password => 'unfiltered',
+    };
+    my $filtered_user = $t->app->yancy->filter->apply( user => $user );
+    is_deeply $filtered_user->{email}, $email, 'filter applied, identity' or diag explain $filtered_user;
+};
+
 subtest 'filter no mutate input' => sub {
     local $t->app->yancy->config->{collections}{user}{properties}{email}{'x-filter'} = [ [ 'yancy.wrap', 'hi' ] ];
     my $user = {

--- a/t/filter.t
+++ b/t/filter.t
@@ -140,6 +140,20 @@ subtest 'register and run parameterised filter' => sub {
     is $filtered_user->{password}, 'unfilteredhi', 'filter params used';
 };
 
+subtest 'run from_helper filter' => sub {
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ [ 'yancy.from_helper', 'yancy.hello' ] ];
+    $t->app->helper( 'yancy.hello' => sub { 'Hi there!' } );
+    my $user = {
+        username => 'filter',
+        email => 'filter@example.com',
+        password => 'unfiltered',
+    };
+    my $filtered_user = $t->app->yancy->filter->apply( user => $user );
+    is $filtered_user->{username}, $user->{username}, 'no filter, no change';
+    is $filtered_user->{email}, $user->{email}, 'no filter, no change';
+    is $filtered_user->{password}, 'Hi there!', 'filter<-helper';
+};
+
 subtest 'filter works recursively' => sub {
     $t->app->yancy->filter->add(
         'test.lc_email' => sub {

--- a/t/filter.t
+++ b/t/filter.t
@@ -97,10 +97,9 @@ my $t = Test::Mojo->new( 'Yancy', {
     read_schema => 1,
 } );
 
-$t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ 'test.digest' ];
-$t->app->yancy->config->{collections}{user}{properties}{password}{'x-digest'} = { type => 'SHA-1' };
-
 subtest 'register and run a filter' => sub {
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ 'test.digest' ];
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-digest'} = { type => 'SHA-1' };
     $t->app->yancy->filter->add(
         'test.digest' => sub {
             my ( $name, $value, $conf ) = @_;
@@ -142,6 +141,8 @@ subtest 'filter works recursively' => sub {
 };
 
 subtest 'api runs filters during set' => sub {
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ 'test.digest' ];
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-digest'} = { type => 'SHA-1' };
     my $doug = {
         %{ $backend->get( user => 'doug' ) },
         password => 'qwe123',
@@ -154,6 +155,8 @@ subtest 'api runs filters during set' => sub {
 };
 
 subtest 'api runs filters during create' => sub {
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ 'test.digest' ];
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-digest'} = { type => 'SHA-1' };
     my $new_user = {
         username => 'qubert',
         email => 'qubert@example.com',
@@ -180,8 +183,8 @@ subtest 'register filters from config' => sub {
         },
     } );
 
-    $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ 'test.digest' ];
-    $t->app->yancy->config->{collections}{user}{properties}{password}{'x-digest'} = { type => 'SHA-1' };
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ 'test.digest' ];
+    local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-digest'} = { type => 'SHA-1' };
 
     my $user = {
         username => 'filter',

--- a/t/filter.t
+++ b/t/filter.t
@@ -140,6 +140,20 @@ subtest 'register and run parameterised filter' => sub {
     is $filtered_user->{password}, 'unfilteredhi', 'filter params used';
 };
 
+subtest 'run wrap filter' => sub {
+    local $t->app->yancy->config->{collections}{user}{properties}{email}{'x-filter'} = [ [ 'yancy.wrap', 'hi' ] ];
+    my $email = 'filter@example.com';
+    my $user = {
+        username => 'unfiltered',
+        email => $email,
+        password => 'unfiltered',
+    };
+    my $filtered_user = $t->app->yancy->filter->apply( user => $user );
+    is $filtered_user->{username}, $user->{username}, 'no filter, no change';
+    is_deeply $filtered_user->{email}, { hi => $email }, 'filter applied' or diag explain $filtered_user;
+    is $filtered_user->{password}, 'unfiltered', 'no filter, no change';
+};
+
 subtest 'run from_helper filter' => sub {
     local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ [ 'yancy.from_helper', 'yancy.hello' ] ];
     $t->app->helper( 'yancy.hello' => sub { 'Hi there!' } );

--- a/t/filter.t
+++ b/t/filter.t
@@ -154,6 +154,17 @@ subtest 'run wrap filter' => sub {
     is $filtered_user->{password}, 'unfiltered', 'no filter, no change';
 };
 
+subtest 'filter no mutate input' => sub {
+    local $t->app->yancy->config->{collections}{user}{properties}{email}{'x-filter'} = [ [ 'yancy.wrap', 'hi' ] ];
+    my $user = {
+        username => 'unfiltered',
+        email => 'filter@example.com',
+        password => 'unfiltered',
+    };
+    my $filtered_user = $t->app->yancy->filter->apply( user => $user );
+    is_deeply $filtered_user->{email}, { hi => $user->{email} }, 'filter did not mutate input' or diag explain $filtered_user;
+};
+
 subtest 'run from_helper filter' => sub {
     local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ [ 'yancy.from_helper', 'yancy.hello' ] ];
     $t->app->helper( 'yancy.hello' => sub { 'Hi there!' } );

--- a/t/filter.t
+++ b/t/filter.t
@@ -173,6 +173,17 @@ subtest 'filter works recursively' => sub {
         'filter on object is run';
 };
 
+subtest 'run overlay_from_helper filter' => sub {
+    local $t->app->yancy->config->{collections}{people}{'x-filter'}[0] = [ 'yancy.overlay_from_helper' => 'email', 'yancy.hello' ];
+    my $person = {
+        name => 'Doug',
+        email => 'dOuG@pReAcTiOn.me',
+    };
+    my $filtered_person = $t->app->yancy->filter->apply( people => $person );
+    is $filtered_person->{email}, 'Hi there!',
+        'filter on object is run';
+};
+
 subtest 'api runs filters during set' => sub {
     local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-filter'} = [ 'test.digest' ];
     local $t->app->yancy->config->{collections}{user}{properties}{password}{'x-digest'} = { type => 'SHA-1' };

--- a/t/filter.t
+++ b/t/filter.t
@@ -63,8 +63,7 @@ my $collections = {
         },
     },
 };
-my ( $backend_url, $backend, %items ) = init_backend(
-    $collections,
+my %data = (
     people => [
         {
             id => 1,
@@ -90,6 +89,7 @@ my ( $backend_url, $backend, %items ) = init_backend(
         },
     ],
 );
+my ( $backend_url, $backend, %items ) = init_backend( $collections, %data );
 
 my $t = Test::Mojo->new( 'Yancy', {
     backend => $backend_url,

--- a/t/helpers.t
+++ b/t/helpers.t
@@ -180,6 +180,12 @@ $t->app->log->handle( $logfh );
 $t->app->yancy->filter->add( foobar => sub { 'foobar' } );
 $backend = $t->app->yancy->backend;
 
+subtest 'yancy.filters' => sub {
+    my $filters = $t->app->yancy->filters;
+    isa_ok $filters, 'HASH';
+    isa_ok $filters->{foobar}, 'CODE';
+};
+
 subtest 'list' => sub {
     my @got_list = $t->app->yancy->list( 'people' );
     is_deeply


### PR DESCRIPTION
Intended to increase the usefulness of filters. Allows them to be configured with parameters under `x-filter`, and also to be configured on OpenAPI operations.

Also adds two filters: `yancy.from_helper` and `yancy.overlay_from_helper`. These are intended for replacing either a single property, or applying to a collection or operation-input hash-ref, with a named helper.