### PR TITLE
Unify rdbms backends

### DIFF
--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -898,7 +898,7 @@ sub _openapi_spec_from_schema {
                         type => ref $props{ $_ }{type} eq 'ARRAY'
                                 ? $props{ $_ }{type}[0] : $props{ $_ }{type},
                         description => "Filter the list by the $_ field. By default, looks for rows containing the value anywhere in the column. Use '*' anywhere in the value to anchor the match.",
-                    } } keys %props,
+                    } } grep !exists( $props{ $_ }{'$ref'} ), keys %props,
                 ],
                 responses => {
                     200 => {

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -209,12 +209,6 @@ sub set_p {
         ->then( sub { !!shift->rows } );
 }
 
-sub delete {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
-}
-
 sub read_schema {
     my ( $self, @table_names ) = @_;
     my $database = $self->mojodb->db->query( 'SELECT DATABASE()' )->array->[0];

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -145,15 +145,10 @@ has mojodb =>;
 use constant mojodb_class => 'Mojo::mysql';
 use constant mojodb_prefix => 'mysql';
 
-sub _id_field {
-    my ( $self, $coll ) = @_;
-    return $self->collections->{ $coll }{ 'x-id-field' } || 'id';
-}
-
 sub create {
     my ( $self, $coll, $params ) = @_;
     $self->_normalize( $coll, $params );
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     my $id = $self->mojodb->db->insert( $coll, $params )->last_insert_id;
     # Assume the id field is correct in case we're using a different
     # unique ID (not the auto-increment column).
@@ -163,20 +158,20 @@ sub create {
 sub create_p {
     my ( $self, $coll, $params ) = @_;
     $self->_normalize( $coll, $params );
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert_p( $coll, $params )
         ->then( sub { $params->{ $id_field } || shift->last_insert_id } );
 }
 
 sub get {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
 }
 
 sub get_p {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     my $db = $self->mojodb->db;
     return $db->select_p( $coll, undef, { $id_field => $id } )
         ->then( sub { shift->hash } );
@@ -228,21 +223,21 @@ sub list_p {
 sub set {
     my ( $self, $coll, $id, $params ) = @_;
     $self->_normalize( $coll, $params );
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
 
 sub set_p {
     my ( $self, $coll, $id, $params ) = @_;
     $self->_normalize( $coll, $params );
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->update_p( $coll, $params, { $id_field => $id } )
         ->then( sub { !!shift->rows } );
 }
 
 sub delete {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
 }
 

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -162,12 +162,6 @@ sub create_p {
         ->then( sub { $params->{ $id_field } || shift->last_insert_id } );
 }
 
-sub get {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
-}
-
 sub list {
     my ( $self, $coll, $params, $opt ) = @_;
     $params ||= {}; $opt ||= {};

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -161,14 +161,6 @@ sub create_p {
         ->then( sub { $params->{ $id_field } || shift->last_insert_id } );
 }
 
-sub set_p {
-    my ( $self, $coll, $id, $params ) = @_;
-    $self->normalize( $coll, $params );
-    my $id_field = $self->id_field( $coll );
-    return $self->mojodb->db->update_p( $coll, $params, { $id_field => $id } )
-        ->then( sub { !!shift->rows } );
-}
-
 sub read_schema {
     my ( $self, @table_names ) = @_;
     my $database = $self->mojodb->db->query( 'SELECT DATABASE()' )->array->[0];

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -121,7 +121,7 @@ L<Mojo::mysql>, L<Yancy>
 use Mojo::Base '-base';
 use Mojo::Promise;
 use Role::Tiny qw( with );
-with qw( Yancy::Backend::Role::Relational );
+with qw( Yancy::Backend::Role::Relational Yancy::Backend::Role::MojoAsync );
 use Scalar::Util qw( looks_like_number );
 BEGIN {
     eval { require Mojo::mysql; Mojo::mysql->VERSION( 1.05 ); 1 }
@@ -244,13 +244,6 @@ sub delete {
     my ( $self, $coll, $id ) = @_;
     my $id_field = $self->_id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
-}
-
-sub delete_p {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
-    return $self->mojodb->db->delete_p( $coll, { $id_field => $id } )
-        ->then( sub { !!shift->rows } );
 }
 
 sub _normalize {

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -119,7 +119,6 @@ L<Mojo::mysql>, L<Yancy>
 =cut
 
 use Mojo::Base '-base';
-use Mojo::Promise;
 use Role::Tiny qw( with );
 with qw( Yancy::Backend::Role::Relational Yancy::Backend::Role::MojoAsync );
 BEGIN {
@@ -160,21 +159,6 @@ sub create_p {
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert_p( $coll, $params )
         ->then( sub { $params->{ $id_field } || shift->last_insert_id } );
-}
-
-sub list_p {
-    my ( $self, $coll, $params, $opt ) = @_;
-    $params ||= {}; $opt ||= {};
-    my $mojodb = $self->mojodb;
-    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
-    my $items_p = $mojodb->db->query_p( $query, @params )->then( sub { shift->hashes } );
-    my $total_p = $mojodb->db->query_p( $total_query, @params )
-        ->then( sub { shift->hash->{total} } );
-    return Mojo::Promise->all( $items_p, $total_p )
-        ->then( sub {
-            my ( $items, $total ) = @_;
-            return { items => $items->[0], total => $total->[0] };
-        } );
 }
 
 sub set_p {

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -120,7 +120,9 @@ L<Mojo::mysql>, L<Yancy>
 
 use Mojo::Base '-base';
 use Mojo::Promise;
-use Scalar::Util qw( blessed looks_like_number );
+use Role::Tiny qw( with );
+with qw( Yancy::Backend::Role::Relational );
+use Scalar::Util qw( looks_like_number );
 BEGIN {
     eval { require Mojo::mysql; Mojo::mysql->VERSION( 1.05 ); 1 }
         or die "Could not load Mysql backend: Mojo::mysql version 1.05 or higher required\n";
@@ -142,26 +144,6 @@ has collections =>;
 has mojodb =>;
 use constant mojodb_class => 'Mojo::mysql';
 use constant mojodb_prefix => 'mysql';
-
-sub new {
-    my ( $class, $backend, $collections ) = @_;
-    if ( !ref $backend ) {
-        my $found = (my $connect = $backend) =~ s#^.*?:##;
-        $backend = $class->mojodb_class->new( $found ? $class->mojodb_prefix.":$connect" : () );
-    }
-    elsif ( !blessed $backend ) {
-        my $attr = $backend;
-        $backend = $class->mojodb_class->new;
-        for my $method ( keys %$attr ) {
-            $backend->$method( $attr->{ $method } );
-        }
-    }
-    my %vars = (
-        mojodb => $backend,
-        collections => $collections,
-    );
-    return $class->SUPER::new( %vars );
-}
 
 sub _id_field {
     my ( $self, $coll ) = @_;

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -122,7 +122,6 @@ use Mojo::Base '-base';
 use Mojo::Promise;
 use Role::Tiny qw( with );
 with qw( Yancy::Backend::Role::Relational Yancy::Backend::Role::MojoAsync );
-use Scalar::Util qw( looks_like_number );
 BEGIN {
     eval { require Mojo::mysql; Mojo::mysql->VERSION( 1.05 ); 1 }
         or die "Could not load Mysql backend: Mojo::mysql version 1.05 or higher required\n";
@@ -169,28 +168,11 @@ sub get {
     return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
 }
 
-sub _list_sqls {
-    my ( $self, $coll, $params, $opt ) = @_;
-    my $mojodb = $self->mojodb;
-    my ( $query, @params ) = $mojodb->abstract->select( $coll, undef, $params, $opt->{order_by} );
-    my ( $total_query, @total_params ) = $mojodb->abstract->select( $coll, [ \'COUNT(*) as total' ], $params );
-    if ( scalar grep defined, @{ $opt }{qw( limit offset )} ) {
-        die "Limit must be number" if $opt->{limit} && !looks_like_number $opt->{limit};
-        $query .= ' LIMIT ' . ( $opt->{limit} // 2**32 );
-        if ( $opt->{offset} ) {
-            die "Offset must be number" if !looks_like_number $opt->{offset};
-            $query .= ' OFFSET ' . $opt->{offset};
-        }
-    }
-    #; say $query;
-    return ( $query, $total_query, @params );
-}
-
 sub list {
     my ( $self, $coll, $params, $opt ) = @_;
     $params ||= {}; $opt ||= {};
     my $mojodb = $self->mojodb;
-    my ( $query, $total_query, @params ) = $self->_list_sqls( $coll, $params, $opt );
+    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
     return {
         items => $mojodb->db->query( $query, @params )->hashes,
         total => $mojodb->db->query( $total_query, @params )->hash->{total},
@@ -201,7 +183,7 @@ sub list_p {
     my ( $self, $coll, $params, $opt ) = @_;
     $params ||= {}; $opt ||= {};
     my $mojodb = $self->mojodb;
-    my ( $query, $total_query, @params ) = $self->_list_sqls( $coll, $params, $opt );
+    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
     my $items_p = $mojodb->db->query_p( $query, @params )->then( sub { shift->hashes } );
     my $total_p = $mojodb->db->query_p( $total_query, @params )
         ->then( sub { shift->hash->{total} } );

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -169,14 +169,6 @@ sub get {
     return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
 }
 
-sub get_p {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    my $db = $self->mojodb->db;
-    return $db->select_p( $coll, undef, { $id_field => $id } )
-        ->then( sub { shift->hash } );
-}
-
 sub _list_sqls {
     my ( $self, $coll, $params, $opt ) = @_;
     my $mojodb = $self->mojodb;

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -194,13 +194,6 @@ sub list_p {
         } );
 }
 
-sub set {
-    my ( $self, $coll, $id, $params ) = @_;
-    $self->normalize( $coll, $params );
-    my $id_field = $self->id_field( $coll );
-    return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
-}
-
 sub set_p {
     my ( $self, $coll, $id, $params ) = @_;
     $self->normalize( $coll, $params );

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -146,7 +146,7 @@ use constant mojodb_prefix => 'mysql';
 
 sub create {
     my ( $self, $coll, $params ) = @_;
-    $self->_normalize( $coll, $params );
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     my $id = $self->mojodb->db->insert( $coll, $params )->last_insert_id;
     # Assume the id field is correct in case we're using a different
@@ -156,7 +156,7 @@ sub create {
 
 sub create_p {
     my ( $self, $coll, $params ) = @_;
-    $self->_normalize( $coll, $params );
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert_p( $coll, $params )
         ->then( sub { $params->{ $id_field } || shift->last_insert_id } );
@@ -196,14 +196,14 @@ sub list_p {
 
 sub set {
     my ( $self, $coll, $id, $params ) = @_;
-    $self->_normalize( $coll, $params );
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
 
 sub set_p {
     my ( $self, $coll, $id, $params ) = @_;
-    $self->_normalize( $coll, $params );
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->update_p( $coll, $params, { $id_field => $id } )
         ->then( sub { !!shift->rows } );
@@ -213,28 +213,6 @@ sub delete {
     my ( $self, $coll, $id ) = @_;
     my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
-}
-
-sub _normalize {
-    my ( $self, $coll, $data ) = @_;
-    my $schema = $self->collections->{ $coll }{ properties };
-    for my $key ( keys %$data ) {
-        my $type = $schema->{ $key }{ type };
-        # Boolean: true (1, "true"), false (0, "false")
-        if ( _is_type( $type, 'boolean' ) ) {
-            $data->{ $key }
-                = $data->{ $key } && $data->{ $key } !~ /^false$/i
-                ? 1 : 0;
-        }
-    }
-}
-
-sub _is_type {
-    my ( $type, $is_type ) = @_;
-    return unless $type;
-    return ref $type eq 'ARRAY'
-        ? !!grep { $_ eq $is_type } @$type
-        : $type eq $is_type;
 }
 
 sub read_schema {

--- a/lib/Yancy/Backend/Mysql.pm
+++ b/lib/Yancy/Backend/Mysql.pm
@@ -162,17 +162,6 @@ sub create_p {
         ->then( sub { $params->{ $id_field } || shift->last_insert_id } );
 }
 
-sub list {
-    my ( $self, $coll, $params, $opt ) = @_;
-    $params ||= {}; $opt ||= {};
-    my $mojodb = $self->mojodb;
-    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
-    return {
-        items => $mojodb->db->query( $query, @params )->hashes,
-        total => $mojodb->db->query( $total_query, @params )->hash->{total},
-    };
-}
-
 sub list_p {
     my ( $self, $coll, $params, $opt ) = @_;
     $params ||= {}; $opt ||= {};

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -143,12 +143,14 @@ use constant mojodb_prefix => 'postgresql';
 
 sub create {
     my ( $self, $coll, $params ) = @_;
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert( $coll, $params, { returning => $id_field } )->hash->{ $id_field };
 }
 
 sub create_p {
     my ( $self, $coll, $params ) = @_;
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert_p( $coll, $params, { returning => $id_field } )
         ->then( sub { shift->hash->{ $id_field } } );
@@ -188,12 +190,14 @@ sub list_p {
 
 sub set {
     my ( $self, $coll, $id, $params ) = @_;
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
 
 sub set_p {
     my ( $self, $coll, $id, $params ) = @_;
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->update_p( $coll, $params, { $id_field => $id } )
         ->then( sub { !!shift->rows } );

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -161,14 +161,6 @@ sub get {
     return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
 }
 
-sub get_p {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    my $db = $self->mojodb->db;
-    return $db->select_p( $coll, undef, { $id_field => $id } )
-        ->then( sub { shift->hash } );
-}
-
 sub _list_sqls {
     my ( $self, $coll, $params, $opt ) = @_;
     my $mojodb = $self->mojodb;

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -120,7 +120,6 @@ L<Mojo::Pg>, L<Yancy>
 =cut
 
 use Mojo::Base '-base';
-use Mojo::Promise;
 use Role::Tiny qw( with );
 with qw( Yancy::Backend::Role::Relational Yancy::Backend::Role::MojoAsync );
 BEGIN {
@@ -154,21 +153,6 @@ sub create_p {
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert_p( $coll, $params, { returning => $id_field } )
         ->then( sub { shift->hash->{ $id_field } } );
-}
-
-sub list_p {
-    my ( $self, $coll, $params, $opt ) = @_;
-    $params ||= {}; $opt ||= {};
-    my $mojodb = $self->mojodb;
-    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
-    my $items_p = $mojodb->db->query_p( $query, @params )->then( sub { shift->hashes } );
-    my $total_p = $mojodb->db->query_p( $total_query, @params )
-        ->then( sub { shift->hash->{total} } );
-    return Mojo::Promise->all( $items_p, $total_p )
-        ->then( sub {
-            my ( $items, $total ) = @_;
-            return { items => $items->[0], total => $total->[0] };
-        } );
 }
 
 sub set_p {

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -121,7 +121,9 @@ L<Mojo::Pg>, L<Yancy>
 
 use Mojo::Base '-base';
 use Mojo::Promise;
-use Scalar::Util qw( looks_like_number blessed );
+use Role::Tiny qw( with );
+with qw( Yancy::Backend::Role::Relational );
+use Scalar::Util qw( looks_like_number );
 BEGIN {
     eval { require Mojo::Pg; Mojo::Pg->VERSION( 4.03 ); 1 }
         or die "Could not load Pg backend: Mojo::Pg version 4.03 or higher required\n";
@@ -139,26 +141,6 @@ has collections =>;
 has mojodb =>;
 use constant mojodb_class => 'Mojo::Pg';
 use constant mojodb_prefix => 'postgresql';
-
-sub new {
-    my ( $class, $backend, $collections ) = @_;
-    if ( !ref $backend ) {
-        my $found = (my $connect = $backend) =~ s#^.*?:##;
-        $backend = $class->mojodb_class->new( $found ? $class->mojodb_prefix.":$connect" : () );
-    }
-    elsif ( !blessed $backend ) {
-        my $attr = $backend;
-        $backend = $class->mojodb_class->new;
-        for my $method ( keys %$attr ) {
-            $backend->$method( $attr->{ $method } );
-        }
-    }
-    my %vars = (
-        mojodb => $backend,
-        collections => $collections,
-    );
-    return $class->SUPER::new( %vars );
-}
 
 sub _id_field {
     my ( $self, $coll ) = @_;

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -55,7 +55,7 @@ Some examples:
     pg://user@/mydb
 
     # User+Pass Host and DB
-    mysql://user:pass@example.com/mydb
+    pg://user:pass@example.com/mydb
 
 =head2 Collections
 

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -156,17 +156,6 @@ sub create_p {
         ->then( sub { shift->hash->{ $id_field } } );
 }
 
-sub list {
-    my ( $self, $coll, $params, $opt ) = @_;
-    $params ||= {}; $opt ||= {};
-    my $mojodb = $self->mojodb;
-    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
-    return {
-        items => $mojodb->db->query( $query, @params )->hashes,
-        total => $mojodb->db->query( $total_query, @params )->hash->{total},
-    };
-}
-
 sub list_p {
     my ( $self, $coll, $params, $opt ) = @_;
     $params ||= {}; $opt ||= {};

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -122,7 +122,7 @@ L<Mojo::Pg>, L<Yancy>
 use Mojo::Base '-base';
 use Mojo::Promise;
 use Role::Tiny qw( with );
-with qw( Yancy::Backend::Role::Relational );
+with qw( Yancy::Backend::Role::Relational Yancy::Backend::Role::MojoAsync );
 use Scalar::Util qw( looks_like_number );
 BEGIN {
     eval { require Mojo::Pg; Mojo::Pg->VERSION( 4.03 ); 1 }
@@ -234,13 +234,6 @@ sub delete {
     my ( $self, $coll, $id ) = @_;
     my $id_field = $self->_id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
-}
-
-sub delete_p {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
-    return $self->mojodb->db->delete_p( $coll, { $id_field => $id } )
-        ->then( sub { !!shift->rows } );
 }
 
 sub read_schema {

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -142,33 +142,28 @@ has mojodb =>;
 use constant mojodb_class => 'Mojo::Pg';
 use constant mojodb_prefix => 'postgresql';
 
-sub _id_field {
-    my ( $self, $coll ) = @_;
-    return $self->collections->{ $coll }{ 'x-id-field' } || 'id';
-}
-
 sub create {
     my ( $self, $coll, $params ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert( $coll, $params, { returning => $id_field } )->hash->{ $id_field };
 }
 
 sub create_p {
     my ( $self, $coll, $params ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->insert_p( $coll, $params, { returning => $id_field } )
         ->then( sub { shift->hash->{ $id_field } } );
 }
 
 sub get {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
 }
 
 sub get_p {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     my $db = $self->mojodb->db;
     return $db->select_p( $coll, undef, { $id_field => $id } )
         ->then( sub { shift->hash } );
@@ -219,20 +214,20 @@ sub list_p {
 
 sub set {
     my ( $self, $coll, $id, $params ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
 
 sub set_p {
     my ( $self, $coll, $id, $params ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->update_p( $coll, $params, { $id_field => $id } )
         ->then( sub { !!shift->rows } );
 }
 
 sub delete {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->_id_field( $coll );
+    my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
 }
 

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -156,12 +156,6 @@ sub create_p {
         ->then( sub { shift->hash->{ $id_field } } );
 }
 
-sub get {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
-}
-
 sub list {
     my ( $self, $coll, $params, $opt ) = @_;
     $params ||= {}; $opt ||= {};

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -155,14 +155,6 @@ sub create_p {
         ->then( sub { shift->hash->{ $id_field } } );
 }
 
-sub set_p {
-    my ( $self, $coll, $id, $params ) = @_;
-    $self->normalize( $coll, $params );
-    my $id_field = $self->id_field( $coll );
-    return $self->mojodb->db->update_p( $coll, $params, { $id_field => $id } )
-        ->then( sub { !!shift->rows } );
-}
-
 sub read_schema {
     my ( $self, @table_names ) = @_;
     my $database = $self->mojodb->db->query( 'SELECT current_schema()' )->array->[0];

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -188,13 +188,6 @@ sub list_p {
         } );
 }
 
-sub set {
-    my ( $self, $coll, $id, $params ) = @_;
-    $self->normalize( $coll, $params );
-    my $id_field = $self->id_field( $coll );
-    return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
-}
-
 sub set_p {
     my ( $self, $coll, $id, $params ) = @_;
     $self->normalize( $coll, $params );

--- a/lib/Yancy/Backend/Pg.pm
+++ b/lib/Yancy/Backend/Pg.pm
@@ -203,12 +203,6 @@ sub set_p {
         ->then( sub { !!shift->rows } );
 }
 
-sub delete {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
-}
-
 sub read_schema {
     my ( $self, @table_names ) = @_;
     my $database = $self->mojodb->db->query( 'SELECT current_schema()' )->array->[0];

--- a/lib/Yancy/Backend/Role/MojoAsync.pm
+++ b/lib/Yancy/Backend/Role/MojoAsync.pm
@@ -35,6 +35,10 @@ Implements L<Yancy::Backend/delete_p>.
 
 Implements L<Yancy::Backend/get_p>.
 
+=head2 list_p
+
+Implements L<Yancy::Backend/list_p>.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -42,6 +46,7 @@ L<Yancy::Backend>
 =cut
 
 use Mojo::Base '-role';
+use Mojo::Promise;
 
 requires qw( mojodb );
 
@@ -58,6 +63,21 @@ sub get_p {
     my $db = $self->mojodb->db;
     return $db->select_p( $coll, undef, { $id_field => $id } )
         ->then( sub { shift->hash } );
+}
+
+sub list_p {
+    my ( $self, $coll, $params, $opt ) = @_;
+    $params ||= {}; $opt ||= {};
+    my $mojodb = $self->mojodb;
+    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
+    my $items_p = $mojodb->db->query_p( $query, @params )->then( sub { shift->hashes } );
+    my $total_p = $mojodb->db->query_p( $total_query, @params )
+        ->then( sub { shift->hash->{total} } );
+    return Mojo::Promise->all( $items_p, $total_p )
+        ->then( sub {
+            my ( $items, $total ) = @_;
+            return { items => $items->[0], total => $total->[0] };
+        } );
 }
 
 1;

--- a/lib/Yancy/Backend/Role/MojoAsync.pm
+++ b/lib/Yancy/Backend/Role/MojoAsync.pm
@@ -1,0 +1,51 @@
+package Yancy::Backend::Role::MojoAsync;
+our $VERSION = '1.023';
+# ABSTRACT: A role to give a relational backend relational capabilities
+
+=head1 SYNOPSIS
+
+    package Yancy::Backend::RDBMS;
+    with 'Yancy::Backend::Role::MojoAsync';
+
+=head1 DESCRIPTION
+
+This role provides utility methods to give backend classes, that
+compose in L<Yancy::Backend::Role::Relational>, implementing asynchronous
+database-access methods.
+
+It is separate from that role in order to be available only for classes
+that do not use L<Yancy::Backend::Role::Sync>, avoiding clashes.
+
+=head1 REQUIRED METHODS
+
+The composing class must implement the following methods either as
+L<constant>s or attributes:
+
+=head2 mojodb
+
+The value must be a relative of L<Mojo::Pg> et al.
+
+=head1 METHODS
+
+=head2 delete_p
+
+Implements L<Yancy::Backend/delete_p>.
+
+=head1 SEE ALSO
+
+L<Yancy::Backend>
+
+=cut
+
+use Mojo::Base '-role';
+
+requires qw( mojodb );
+
+sub delete_p {
+    my ( $self, $coll, $id ) = @_;
+    my $id_field = $self->_id_field( $coll );
+    return $self->mojodb->db->delete_p( $coll, { $id_field => $id } )
+        ->then( sub { !!shift->rows } );
+}
+
+1;

--- a/lib/Yancy/Backend/Role/MojoAsync.pm
+++ b/lib/Yancy/Backend/Role/MojoAsync.pm
@@ -31,6 +31,10 @@ The value must be a relative of L<Mojo::Pg> et al.
 
 Implements L<Yancy::Backend/delete_p>.
 
+=head2 get_p
+
+Implements L<Yancy::Backend/get_p>.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -46,6 +50,14 @@ sub delete_p {
     my $id_field = $self->_id_field( $coll );
     return $self->mojodb->db->delete_p( $coll, { $id_field => $id } )
         ->then( sub { !!shift->rows } );
+}
+
+sub get_p {
+    my ( $self, $coll, $id ) = @_;
+    my $id_field = $self->id_field( $coll );
+    my $db = $self->mojodb->db;
+    return $db->select_p( $coll, undef, { $id_field => $id } )
+        ->then( sub { shift->hash } );
 }
 
 1;

--- a/lib/Yancy/Backend/Role/MojoAsync.pm
+++ b/lib/Yancy/Backend/Role/MojoAsync.pm
@@ -39,6 +39,10 @@ Implements L<Yancy::Backend/get_p>.
 
 Implements L<Yancy::Backend/list_p>.
 
+=head2 set_p
+
+Implements L<Yancy::Backend/set_p>.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -78,6 +82,14 @@ sub list_p {
             my ( $items, $total ) = @_;
             return { items => $items->[0], total => $total->[0] };
         } );
+}
+
+sub set_p {
+    my ( $self, $coll, $id, $params ) = @_;
+    $self->normalize( $coll, $params );
+    my $id_field = $self->id_field( $coll );
+    return $self->mojodb->db->update_p( $coll, $params, { $id_field => $id } )
+        ->then( sub { !!shift->rows } );
 }
 
 1;

--- a/lib/Yancy/Backend/Role/Relational.pm
+++ b/lib/Yancy/Backend/Role/Relational.pm
@@ -45,6 +45,10 @@ Given a collection, returns the string name of its ID field.
 Given a collection, parameters and options, returns SQL to generate the
 actual results, the count results, and the bind-parameters.
 
+=head2 normalize
+
+Given a collection and data, normalises any boolean values to 1 and 0.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -96,6 +100,28 @@ sub list_sqls {
     }
     #; say $query;
     return ( $query, $total_query, @params );
+}
+
+sub normalize {
+    my ( $self, $coll, $data ) = @_;
+    my $schema = $self->collections->{ $coll }{ properties };
+    for my $key ( keys %$data ) {
+        my $type = $schema->{ $key }{ type };
+        # Boolean: true (1, "true"), false (0, "false")
+        if ( _is_type( $type, 'boolean' ) ) {
+            $data->{ $key }
+                = $data->{ $key } && $data->{ $key } !~ /^false$/i
+                ? 1 : 0;
+        }
+    }
+}
+
+sub _is_type {
+    my ( $type, $is_type ) = @_;
+    return unless $type;
+    return ref $type eq 'ARRAY'
+        ? !!grep { $_ eq $is_type } @$type
+        : $type eq $is_type;
 }
 
 1;

--- a/lib/Yancy/Backend/Role/Relational.pm
+++ b/lib/Yancy/Backend/Role/Relational.pm
@@ -36,6 +36,10 @@ String with the value at the start of a L<DBI> C<dsn>.
 
 Self-explanatory, implements L<Yancy::Backend/new>.
 
+=head2 id_field
+
+Given a collection, returns the string name of its ID field.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -65,6 +69,11 @@ sub new {
         collections => $collections,
     );
     Mojo::Base::new( $class, %vars );
+}
+
+sub id_field {
+    my ( $self, $coll ) = @_;
+    return $self->collections->{ $coll }{ 'x-id-field' } || 'id';
 }
 
 1;

--- a/lib/Yancy/Backend/Role/Relational.pm
+++ b/lib/Yancy/Backend/Role/Relational.pm
@@ -53,6 +53,10 @@ Given a collection and data, normalises any boolean values to 1 and 0.
 
 Self-explanatory, implements L<Yancy::Backend/delete>.
 
+=head2 set
+
+Self-explanatory, implements L<Yancy::Backend/set>.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -132,6 +136,13 @@ sub delete {
     my ( $self, $coll, $id ) = @_;
     my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
+}
+
+sub set {
+    my ( $self, $coll, $id, $params ) = @_;
+    $self->normalize( $coll, $params );
+    my $id_field = $self->id_field( $coll );
+    return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
 
 1;

--- a/lib/Yancy/Backend/Role/Relational.pm
+++ b/lib/Yancy/Backend/Role/Relational.pm
@@ -49,6 +49,10 @@ actual results, the count results, and the bind-parameters.
 
 Given a collection and data, normalises any boolean values to 1 and 0.
 
+=head2 delete
+
+Self-explanatory, implements L<Yancy::Backend/delete>.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -122,6 +126,12 @@ sub _is_type {
     return ref $type eq 'ARRAY'
         ? !!grep { $_ eq $is_type } @$type
         : $type eq $is_type;
+}
+
+sub delete {
+    my ( $self, $coll, $id ) = @_;
+    my $id_field = $self->id_field( $coll );
+    return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
 }
 
 1;

--- a/lib/Yancy/Backend/Role/Relational.pm
+++ b/lib/Yancy/Backend/Role/Relational.pm
@@ -61,6 +61,10 @@ Self-explanatory, implements L<Yancy::Backend/set>.
 
 Self-explanatory, implements L<Yancy::Backend/get>.
 
+=head2 list
+
+Self-explanatory, implements L<Yancy::Backend/list>.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -153,6 +157,17 @@ sub get {
     my ( $self, $coll, $id ) = @_;
     my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
+}
+
+sub list {
+    my ( $self, $coll, $params, $opt ) = @_;
+    $params ||= {}; $opt ||= {};
+    my $mojodb = $self->mojodb;
+    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
+    return {
+        items => $mojodb->db->query( $query, @params )->hashes,
+        total => $mojodb->db->query( $total_query, @params )->hash->{total},
+    };
 }
 
 1;

--- a/lib/Yancy/Backend/Role/Relational.pm
+++ b/lib/Yancy/Backend/Role/Relational.pm
@@ -1,0 +1,70 @@
+package Yancy::Backend::Role::Relational;
+our $VERSION = '1.023';
+# ABSTRACT: A role to give a relational backend relational capabilities
+
+=head1 SYNOPSIS
+
+    package Yancy::Backend::RDBMS;
+    with 'Yancy::Backend::Role::Relational';
+
+=head1 DESCRIPTION
+
+This role implements utility methods to make backend classes work with
+entity relations, using L<DBI> methods such as
+C<DBI/foreign_key_info>.
+
+=head1 REQUIRED METHODS
+
+The composing class must implement the following methods either as
+L<constant>s or attributes:
+
+=head2 mojodb
+
+The value must be a relative of L<Mojo::Pg> et al.
+
+=head2 mojodb_class
+
+String naming the C<Mojo::*> class.
+
+=head2 mojodb_prefix
+
+String with the value at the start of a L<DBI> C<dsn>.
+
+=head1 METHODS
+
+=head2 new
+
+Self-explanatory, implements L<Yancy::Backend/new>.
+
+=head1 SEE ALSO
+
+L<Yancy::Backend>
+
+=cut
+
+use Mojo::Base '-role';
+use Scalar::Util qw( blessed );
+
+requires qw( mojodb mojodb_class mojodb_prefix );
+
+sub new {
+    my ( $class, $backend, $collections ) = @_;
+    if ( !ref $backend ) {
+        my $found = (my $connect = $backend) =~ s#^.*?:##;
+        $backend = $class->mojodb_class->new( $found ? $class->mojodb_prefix.":$connect" : () );
+    }
+    elsif ( !blessed $backend ) {
+        my $attr = $backend;
+        $backend = $class->mojodb_class->new;
+        for my $method ( keys %$attr ) {
+            $backend->$method( $attr->{ $method } );
+        }
+    }
+    my %vars = (
+        mojodb => $backend,
+        collections => $collections,
+    );
+    Mojo::Base::new( $class, %vars );
+}
+
+1;

--- a/lib/Yancy/Backend/Role/Relational.pm
+++ b/lib/Yancy/Backend/Role/Relational.pm
@@ -57,6 +57,10 @@ Self-explanatory, implements L<Yancy::Backend/delete>.
 
 Self-explanatory, implements L<Yancy::Backend/set>.
 
+=head2 get
+
+Self-explanatory, implements L<Yancy::Backend/get>.
+
 =head1 SEE ALSO
 
 L<Yancy::Backend>
@@ -143,6 +147,12 @@ sub set {
     $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
+}
+
+sub get {
+    my ( $self, $coll, $id ) = @_;
+    my $id_field = $self->id_field( $coll );
+    return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
 }
 
 1;

--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -166,13 +166,6 @@ sub list {
     };
 }
 
-sub set {
-    my ( $self, $coll, $id, $params ) = @_;
-    $self->normalize( $coll, $params );
-    my $id_field = $self->id_field( $coll );
-    return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
-}
-
 sub read_schema {
     my ( $self, @table_names ) = @_;
     my %schema;

--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -143,7 +143,7 @@ use constant mojodb_prefix => 'sqlite';
 sub create {
     my ( $self, $coll, $params ) = @_;
     $self->_normalize( $coll, $params );
-    my $id_field = $self->collections->{ $coll }{ 'x-id-field' } || 'id';
+    my $id_field = $self->id_field( $coll );
     my $inserted_id = $self->mojodb->db->insert( $coll, $params )->last_insert_id;
     # SQLite does not have a 'returning' syntax. Assume id field is correct
     # if passed, created otherwise:
@@ -152,7 +152,7 @@ sub create {
 
 sub get {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->collections->{ $coll }{ 'x-id-field' } || 'id';
+    my $id_field = $self->id_field( $coll );
     return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
 }
 
@@ -181,13 +181,13 @@ sub list {
 sub set {
     my ( $self, $coll, $id, $params ) = @_;
     $self->_normalize( $coll, $params );
-    my $id_field = $self->collections->{ $coll }{ 'x-id-field' } || 'id';
+    my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
 
 sub delete {
     my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->collections->{ $coll }{ 'x-id-field' } || 'id';
+    my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
 }
 

--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -141,7 +141,7 @@ use constant mojodb_prefix => 'sqlite';
 
 sub create {
     my ( $self, $coll, $params ) = @_;
-    $self->_normalize( $coll, $params );
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     my $inserted_id = $self->mojodb->db->insert( $coll, $params )->last_insert_id;
     # SQLite does not have a 'returning' syntax. Assume id field is correct
@@ -168,7 +168,7 @@ sub list {
 
 sub set {
     my ( $self, $coll, $id, $params ) = @_;
-    $self->_normalize( $coll, $params );
+    $self->normalize( $coll, $params );
     my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
@@ -177,28 +177,6 @@ sub delete {
     my ( $self, $coll, $id ) = @_;
     my $id_field = $self->id_field( $coll );
     return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
-}
-
-sub _normalize {
-    my ( $self, $coll, $data ) = @_;
-    my $schema = $self->collections->{ $coll }{ properties };
-    for my $key ( keys %$data ) {
-        my $type = $schema->{ $key }{ type };
-        # Boolean: true (1, "true"), false (0, "false")
-        if ( _is_type( $type, 'boolean' ) ) {
-            $data->{ $key }
-                = $data->{ $key } && $data->{ $key } !~ /^false$/i
-                ? 1 : 0;
-        }
-    }
-}
-
-sub _is_type {
-    my ( $type, $is_type ) = @_;
-    return unless $type;
-    return ref $type eq 'ARRAY'
-        ? !!grep { $_ eq $is_type } @$type
-        : $type eq $is_type;
 }
 
 sub read_schema {

--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -115,8 +115,8 @@ L<Mojo::SQLite>, L<Yancy>
 
 use Mojo::Base '-base';
 use Role::Tiny qw( with );
-with 'Yancy::Backend::Role::Sync';
-use Scalar::Util qw( looks_like_number blessed );
+with qw( Yancy::Backend::Role::Sync Yancy::Backend::Role::Relational );
+use Scalar::Util qw( looks_like_number );
 use Text::Balanced qw( extract_bracketed );
 BEGIN {
     eval { require Mojo::SQLite; Mojo::SQLite->VERSION( 3 ); 1 }
@@ -139,26 +139,6 @@ has collections =>;
 has mojodb =>;
 use constant mojodb_class => 'Mojo::SQLite';
 use constant mojodb_prefix => 'sqlite';
-
-sub new {
-    my ( $class, $backend, $collections ) = @_;
-    if ( !ref $backend ) {
-        my $found = (my $connect = $backend) =~ s#^.*?:##;
-        $backend = $class->mojodb_class->new( $found ? $class->mojodb_prefix.":$connect" : () );
-    }
-    elsif ( !blessed $backend ) {
-        my $attr = $backend;
-        $backend = $class->mojodb_class->new;
-        for my $method ( keys %$attr ) {
-            $backend->$method( $attr->{ $method } );
-        }
-    }
-    my %vars = (
-        mojodb => $backend,
-        collections => $collections,
-    );
-    return $class->SUPER::new( %vars );
-}
 
 sub create {
     my ( $self, $coll, $params ) = @_;

--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -173,12 +173,6 @@ sub set {
     return !!$self->mojodb->db->update( $coll, $params, { $id_field => $id } )->rows;
 }
 
-sub delete {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    return !!$self->mojodb->db->delete( $coll, { $id_field => $id } )->rows;
-}
-
 sub read_schema {
     my ( $self, @table_names ) = @_;
     my %schema;

--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -149,12 +149,6 @@ sub create {
     return $params->{$id_field} || $inserted_id;
 }
 
-sub get {
-    my ( $self, $coll, $id ) = @_;
-    my $id_field = $self->id_field( $coll );
-    return $self->mojodb->db->select( $coll, undef, { $id_field => $id } )->hash;
-}
-
 sub list {
     my ( $self, $coll, $params, $opt ) = @_;
     $params ||= {}; $opt ||= {};

--- a/lib/Yancy/Backend/Sqlite.pm
+++ b/lib/Yancy/Backend/Sqlite.pm
@@ -149,17 +149,6 @@ sub create {
     return $params->{$id_field} || $inserted_id;
 }
 
-sub list {
-    my ( $self, $coll, $params, $opt ) = @_;
-    $params ||= {}; $opt ||= {};
-    my $mojodb = $self->mojodb;
-    my ( $query, $total_query, @params ) = $self->list_sqls( $coll, $params, $opt );
-    return {
-        items => $mojodb->db->query( $query, @params )->hashes,
-        total => $mojodb->db->query( $total_query, @params )->hash->{total},
-    };
-}
-
 sub read_schema {
     my ( $self, @table_names ) = @_;
     my %schema;

--- a/share/run_backend_tests.pl
+++ b/share/run_backend_tests.pl
@@ -150,7 +150,7 @@ DB: for my $db ( @tests ) {
     }
 
     local %ENV = ( %ENV, %{ $test->{env} } );
-    system( qw( prove -lr ), @files );
+    system( qw( prove -j1 -lr ), @files );
     if ( $? != 0 ) {
         say "Test failure ($db): $?";
         last;

--- a/t/backend/mysql.t
+++ b/t/backend/mysql.t
@@ -43,19 +43,19 @@ use Local::Test qw( test_backend );
 
 use Mojo::mysql;
 # Isolate test data
-my $mysql = Mojo::mysql->new($ENV{TEST_ONLINE_MYSQL});
-$mysql->db->query('DROP DATABASE IF EXISTS yancy_mysql_test');
-$mysql->db->query('CREATE DATABASE yancy_mysql_test');
-$mysql->db->query('USE yancy_mysql_test');
+my $mojodb = Mojo::mysql->new($ENV{TEST_ONLINE_MYSQL});
+$mojodb->db->query('DROP DATABASE IF EXISTS yancy_mysql_test');
+$mojodb->db->query('CREATE DATABASE yancy_mysql_test');
+$mojodb->db->query('USE yancy_mysql_test');
 
-$mysql->db->query(
+$mojodb->db->query(
     'CREATE TABLE people (
         id INTEGER AUTO_INCREMENT PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
         `email` VARCHAR(255) UNIQUE
     )',
 );
-$mysql->db->query(
+$mojodb->db->query(
     q{CREATE TABLE `user` (
         `username` VARCHAR(255) PRIMARY KEY,
         `email` VARCHAR(255) NOT NULL,
@@ -63,7 +63,7 @@ $mysql->db->query(
         `created` DATETIME DEFAULT '2018-03-01 00:00:00'
     )},
 );
-$mysql->db->query(q{
+$mojodb->db->query(q{
     CREATE TABLE mojo_migrations (
         name VARCHAR(255) UNIQUE NOT NULL,
         version INTEGER NOT NULL
@@ -103,25 +103,25 @@ my $be;
 subtest 'new' => sub {
     $be = Yancy::Backend::Mysql->new( $ENV{TEST_ONLINE_MYSQL}, $collections );
     isa_ok $be, 'Yancy::Backend::Mysql';
-    isa_ok $be->mysql, 'Mojo::mysql';
+    isa_ok $be->mojodb, 'Mojo::mysql';
     is_deeply $be->collections, $collections;
 
     subtest 'new with connection' => sub {
-        $be = Yancy::Backend::Mysql->new( $mysql, $collections );
+        $be = Yancy::Backend::Mysql->new( $mojodb, $collections );
         isa_ok $be, 'Yancy::Backend::Mysql';
-        isa_ok $be->mysql, 'Mojo::mysql';
+        isa_ok $be->mojodb, 'Mojo::mysql';
         is_deeply $be->collections, $collections;
     };
 
     subtest 'new with attributes' => sub {
         my %attr = (
-            dsn => $mysql->dsn,
-            username => $mysql->username,
-            password => $mysql->password,
+            dsn => $mojodb->dsn,
+            username => $mojodb->username,
+            password => $mojodb->password,
         );
         $be = Yancy::Backend::Mysql->new( \%attr, $collections );
         isa_ok $be, 'Yancy::Backend::Mysql';
-        isa_ok $be->mysql, 'Mojo::mysql';
+        isa_ok $be->mojodb, 'Mojo::mysql';
         is_deeply $be->collections, $collections;
     };
 };
@@ -129,7 +129,7 @@ subtest 'new' => sub {
 sub insert_item {
     my ( $coll, %item ) = @_;
     my $id_field = $collections->{ $coll }{ 'x-id-field' } || 'id';
-    my $id = $mysql->db->insert( $coll => \%item )->last_insert_id;
+    my $id = $mojodb->db->insert( $coll => \%item )->last_insert_id;
     $item{ $id_field } ||= $id;
     return %item;
 }

--- a/t/backend/pg.t
+++ b/t/backend/pg.t
@@ -40,21 +40,21 @@ use Local::Test qw( test_backend );
 
 use Mojo::Pg;
 # Isolate test data
-my $pg = Mojo::Pg->new($ENV{TEST_ONLINE_PG})->search_path(['yancy_pg_test']);
-$pg->db->query('DROP SCHEMA IF EXISTS yancy_pg_test CASCADE');
-$pg->db->query('CREATE SCHEMA yancy_pg_test');
+my $mojodb = Mojo::Pg->new($ENV{TEST_ONLINE_PG})->search_path(['yancy_pg_test']);
+$mojodb->db->query('DROP SCHEMA IF EXISTS yancy_pg_test CASCADE');
+$mojodb->db->query('CREATE SCHEMA yancy_pg_test');
 
-$pg->db->query(
+$mojodb->db->query(
     q{CREATE TYPE access_level AS ENUM ( 'user', 'moderator', 'admin' )},
 );
-$pg->db->query(
+$mojodb->db->query(
     q{CREATE TABLE people (
         id SERIAL PRIMARY KEY,
         name VARCHAR NOT NULL,
         email VARCHAR UNIQUE
     )}
 );
-$pg->db->query(
+$mojodb->db->query(
     q{CREATE TABLE "user" (
         username VARCHAR PRIMARY KEY,
         email VARCHAR NOT NULL,
@@ -62,7 +62,7 @@ $pg->db->query(
         created TIMESTAMP DEFAULT '2018-03-01 00:00:00'
     )}
 );
-$pg->db->query(q{
+$mojodb->db->query(q{
     CREATE TABLE mojo_migrations (
         name VARCHAR(255) UNIQUE NOT NULL,
         version INTEGER NOT NULL
@@ -102,29 +102,29 @@ my $be;
 subtest 'new' => sub {
     $be = Yancy::Backend::Pg->new( $ENV{TEST_ONLINE_PG}, $collections );
     isa_ok $be, 'Yancy::Backend::Pg';
-    isa_ok $be->pg, 'Mojo::Pg';
+    isa_ok $be->mojodb, 'Mojo::Pg';
     is_deeply $be->collections, $collections;
 
     subtest 'new with connection' => sub {
-        $be = Yancy::Backend::Pg->new( $pg, $collections );
+        $be = Yancy::Backend::Pg->new( $mojodb, $collections );
         isa_ok $be, 'Yancy::Backend::Pg';
-        isa_ok $be->pg, 'Mojo::Pg';
+        isa_ok $be->mojodb, 'Mojo::Pg';
         is_deeply $be->collections, $collections;
     };
 
     subtest 'new with hashref' => sub {
         my %attr = (
-            dsn => $pg->dsn,
-            username => $pg->username,
-            password => $pg->password,
-            search_path => $pg->search_path,
+            dsn => $mojodb->dsn,
+            username => $mojodb->username,
+            password => $mojodb->password,
+            search_path => $mojodb->search_path,
         );
         $be = Yancy::Backend::Pg->new( \%attr, $collections );
         isa_ok $be, 'Yancy::Backend::Pg';
-        isa_ok $be->pg, 'Mojo::Pg';
-        is $be->pg->dsn, $attr{dsn}, 'dsn is correct';
-        is $be->pg->username, $attr{username}, 'username is correct';
-        is $be->pg->password, $attr{password}, 'password is correct';
+        isa_ok $be->mojodb, 'Mojo::Pg';
+        is $be->mojodb->dsn, $attr{dsn}, 'dsn is correct';
+        is $be->mojodb->username, $attr{username}, 'username is correct';
+        is $be->mojodb->password, $attr{password}, 'password is correct';
         is_deeply $be->collections, $collections;
     };
 };
@@ -132,7 +132,7 @@ subtest 'new' => sub {
 sub insert_item {
     my ( $coll, %item ) = @_;
     my $id_field = $collections->{ $coll }{ 'x-id-field' } || 'id';
-    my $id = $pg->db->insert( $coll => \%item, { returning => $id_field } )->hash->{$id_field};
+    my $id = $mojodb->db->insert( $coll => \%item, { returning => $id_field } )->hash->{$id_field};
     $item{ $id_field } = $id;
     return %item;
 }

--- a/t/backend/sqlite.t
+++ b/t/backend/sqlite.t
@@ -35,16 +35,16 @@ use Mojo::SQLite;
 # c.f., https://metacpan.org/pod/DBD::SQLite#Database-Name-Is-A-File-Name
 # unless TEST_ONLINE_SQLITE is set, in which case use that
 
-my $sqlite = Mojo::SQLite->new($ENV{TEST_ONLINE_SQLITE});
+my $mojodb = Mojo::SQLite->new($ENV{TEST_ONLINE_SQLITE});
 
-$sqlite->db->query(
+$mojodb->db->query(
     'CREATE TABLE people (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         name VARCHAR(255) NOT NULL,
         email VARCHAR(255) UNIQUE
     )',
 );
-$sqlite->db->query(
+$mojodb->db->query(
     q{CREATE TABLE "user" (
         username VARCHAR(255) PRIMARY KEY,
         email VARCHAR(255) NOT NULL,
@@ -52,7 +52,7 @@ $sqlite->db->query(
         created TIMESTAMP DEFAULT '2018-03-01 00:00:00'
     )},
 );
-$sqlite->db->query(q{
+$mojodb->db->query(q{
     CREATE TABLE mojo_migrations (
         name VARCHAR(255) UNIQUE NOT NULL,
         version INTEGER NOT NULL
@@ -92,35 +92,35 @@ my $be;
 subtest 'new' => sub {
     $be = Yancy::Backend::Sqlite->new( '', $collections );
     isa_ok $be, 'Yancy::Backend::Sqlite';
-    isa_ok $be->sqlite, 'Mojo::SQLite';
+    isa_ok $be->mojodb, 'Mojo::SQLite';
     is_deeply $be->collections, $collections;
 
     subtest 'new with connection' => sub {
-        $be = Yancy::Backend::Sqlite->new( $sqlite, $collections );
+        $be = Yancy::Backend::Sqlite->new( $mojodb, $collections );
         isa_ok $be, 'Yancy::Backend::Sqlite';
-        isa_ok $be->sqlite, 'Mojo::SQLite';
+        isa_ok $be->mojodb, 'Mojo::SQLite';
         is_deeply $be->collections, $collections;
     };
 
     subtest 'new with hashref' => sub {
         my %attr = (
-            dsn => $sqlite->dsn,
+            dsn => $mojodb->dsn,
         );
         $be = Yancy::Backend::Sqlite->new( \%attr, $collections );
         isa_ok $be, 'Yancy::Backend::Sqlite';
-        isa_ok $be->sqlite, 'Mojo::SQLite';
-        is $be->sqlite->dsn, $attr{dsn}, 'dsn is correct';
+        isa_ok $be->mojodb, 'Mojo::SQLite';
+        is $be->mojodb->dsn, $attr{dsn}, 'dsn is correct';
         is_deeply $be->collections, $collections;
     };
 };
 
 # Override sqlite attribute with reference to instantiated db object from above
-$be->sqlite( $sqlite );
+$be->mojodb( $mojodb );
 
 sub insert_item {
     my ( $coll, %item ) = @_;
     my $id_field = $collections->{ $coll }{ 'x-id-field' } || 'id';
-    my $inserted_id = $sqlite->db->insert( $coll => \%item )->last_insert_id;
+    my $inserted_id = $mojodb->db->insert( $coll => \%item )->last_insert_id;
     # SQLite does not have a 'returning' syntax. Assume ID is stored
     # if passed, computed if undef:
     $item{ $id_field } //= $inserted_id;

--- a/t/config.t
+++ b/t/config.t
@@ -153,13 +153,13 @@ subtest 'x-ignore' => sub {
     my $t = Test::Mojo->new( Yancy => {
         read_schema => 1,
         backend => $backend_url,
-        collections => { user => { 'x-ignore' => 1 } },
+        collections => { blog => { 'x-ignore' => 1 } },
     });
     $t->get_ok( '/yancy/api' )
       ->status_is( 200 )
       ->content_type_like( qr{^application/json} )
       ->json_has( '/definitions/people', 'people read from schema' )
-      ->json_hasnt( '/definitions/user', 'user ignored from schema' )
+      ->json_hasnt( '/definitions/blog', 'blog ignored from schema' )
       ;
 };
 

--- a/t/controller/multi_tenant.t
+++ b/t/controller/multi_tenant.t
@@ -13,7 +13,6 @@ L<Yancy::Controller::Yancy::MultiTenant>
 use Mojo::Base '-strict';
 use Test::More;
 use Test::Mojo;
-use Mojo::JSON qw( true false );
 use FindBin qw( $Bin );
 use Mojo::File qw( path );
 use lib "".path( $Bin, '..', 'lib' );

--- a/t/controller/yancy.t
+++ b/t/controller/yancy.t
@@ -178,7 +178,7 @@ $r->get( '/:id/:slug' )
 $r->get( '/:page', { page => 1 } )
     ->to( 'yancy#list' => collection => 'blog', template => 'blog_list' )
     ->name( 'blog.list' );
-$r->get( '/list/user/1/:page', { filter => { user_id => $items{user}[0]{id} }, page => 1 } )
+$r->get( '/list/user/1/:page', { filter => { id => $items{blog}[0]{id} }, page => 1 } )
     ->to( 'yancy#list' => collection => 'blog', template => 'blog_list' );
 
 subtest 'list' => sub {

--- a/t/lib/Yancy/Backend/Test.pm
+++ b/t/lib/Yancy/Backend/Test.pm
@@ -82,6 +82,10 @@ sub list {
             $sort_order = [keys %{ $opt->{order_by} }]->[0];
         }
     }
+    for my $filter_param (keys %$params) {
+        die "Can't filter by non-existent parameter '$filter_param'"
+            if !exists $SCHEMA{ $coll }{properties}{ $filter_param };
+    }
 
     my @rows = sort {
         $sort_order eq '-asc'


### PR DESCRIPTION
Intended to help implement relations between collections. The common code, using at least the DBI method `foreign_key_info` for `read_schema`, will be able to go in the various roles.

The unifying has also had a slight tidying effect, e.g. the Pg code wasn't doing `normalize`.