### PR TITLE
Add import stringifying the log message

### DIFF
--- a/lib/Yancy/Controller/Yancy.pm
+++ b/lib/Yancy/Controller/Yancy.pm
@@ -158,6 +158,7 @@ L<Yancy>
 =cut
 
 use Mojo::Base 'Mojolicious::Controller';
+use Mojo::JSON qw( to_json );
 use Yancy::Util qw( derp );
 use POSIX qw( ceil );
 


### PR DESCRIPTION
I think being a base to Mojolicious::Controller doesn't give you to_json, at least in Mojolicious 8.23.

This PR replaces a log message like
```
[2019-08-29 11:38:47.99478] [6638] [error] Undefined subroutine &Yancy::Controller::Yancy::to_json called at /Library/Perl/5.18/Yancy/Controller/Yancy.pm line 310.
```
with a slightly less cryptic
```
[2019-08-29 11:42:49.78252] [6643] [error] Sorry type '"array"' is not handled yet, only string|number|integer|boolean is supported. at /Library/Perl/5.18/Yancy/Controller/Yancy.pm line 311.
```