### PR TITLE
If you submit without a required markdown field, the UI should tell you

### DIFF
--- a/lib/Mojolicious/Plugin/Yancy/resources/templates/yancy/index.html.ep
+++ b/lib/Mojolicious/Plugin/Yancy/resources/templates/yancy/index.html.ep
@@ -544,7 +544,7 @@
                 </button>
             </div>
             <div class="markdown-editor-panels">
-                <textarea v-model="$data._value" @change="input" :class="{collapse:showHtml}"></textarea>
+                <textarea v-model="$data._value" @change="input" :required="required" :disabled="readonly" :class="{collapse:showHtml}"></textarea>
                 <div v-html="html" :class="{collapse:!showHtml}"></div>
             </div>
         </div>


### PR DESCRIPTION
With this patch, it tells you when you click submit and don't fill in the e.g. path - the field goes red and it says "please fill in this field" - at least in Firefox set to English. Without the patch, the submit doesn't do anything - minor bug.

I didn't test the "readonly" - when I set readOnly in the schema, it's not shown in the editor, which is a separate issue - but anyway it seems right to make it like in the textarea field.