### PR TITLE
Openapi endpoints

### DIFF
--- a/lib/Yancy/Controller/Yancy.pm
+++ b/lib/Yancy/Controller/Yancy.pm
@@ -307,10 +307,13 @@ sub list {
         elsif ( _is_type( $type, 'boolean' ) ) {
             $param_filter{ $value ? '-bool' : '-not_bool' } = $key;
         }
+        elsif ( _is_type($type, 'array') ) {
+            $param_filter{ $key } = { '-has' =>  $value };
+        }
         else {
             die "Sorry type '" .
                 to_json( $type ) .
-                "' is not handled yet, only string|number|integer|boolean is supported."
+                "' is not handled yet, only string|number|integer|boolean|array is supported."
         }
     }
     my $filter = {

--- a/lib/Yancy/Controller/Yancy.pm
+++ b/lib/Yancy/Controller/Yancy.pm
@@ -305,7 +305,7 @@ sub list {
             $param_filter{ $key } = $value ;
         }
         elsif ( _is_type( $type, 'boolean' ) ) {
-            $param_filter{ $value ? '-bool' : '-not_bool' } = $key;
+            $param_filter{ ($value && $value ne 'false')? '-bool' : '-not_bool' } = $key;
         }
         elsif ( _is_type($type, 'array') ) {
             $param_filter{ $key } = { '-has' =>  $value };

--- a/lib/Yancy/Plugin/Editor.pm
+++ b/lib/Yancy/Plugin/Editor.pm
@@ -448,12 +448,20 @@ sub _openapi_spec_from_schema {
                     { '$ref' => '#/parameters/%24limit' },
                     { '$ref' => '#/parameters/%24offset' },
                     { '$ref' => '#/parameters/%24order_by' },
-                    map {; {
-                        name => $_,
+                    map {
+                        my $name = $_;
+                        my $type = ref $props{ $_ }{type} eq 'ARRAY' ? $props{ $_ }{type}[0] : $props{ $_ }{type};
+                        my $description =
+                           $type eq 'number' || $type eq 'integer' ? "Looks for records where the $type is equal to the value."
+                           : $type eq 'boolean' ? "Looks for records where the boolean is true/false."
+                           : $type eq 'array' ? "Looks for records where the array contains the value."
+                           : "By default, looks for records containing the value anywhere in the column. Use '*' anywhere in the value to anchor the match.";
+
+                        {
+                        name => $name,
                         in => 'query',
-                        type => ref $props{ $_ }{type} eq 'ARRAY'
-                                ? $props{ $_ }{type}[0] : $props{ $_ }{type},
-                        description => "Filter the list by the $_ field. By default, looks for rows containing the value anywhere in the column. Use '*' anywhere in the value to anchor the match.",
+                        type => $type,
+                        description => "Filter the list by the $name field. " . $description,
                     } } grep !exists( $props{ $_ }{'$ref'} ), sort keys %props,
                 ],
                 responses => {

--- a/t/plugin/editor.t
+++ b/t/plugin/editor.t
@@ -59,6 +59,15 @@ subtest 'non-default backend' => sub {
                 name => {
                     type => 'string',
                 },
+                is_good => {
+                    type => 'boolean',
+                },
+                num_legs => {
+                    type => 'integer',
+                },
+                equipment => {
+                    type => 'array',
+                },
                 type => {
                     type => 'string',
                     enum => [qw( cat dog bird rat snake )],
@@ -70,10 +79,16 @@ subtest 'non-default backend' => sub {
     my $ted = {
         name => 'Theodore',
         type => 'cat',
+        is_good => undef,
+        num_legs => 4,
+        equipment => [],
     };
     my $franklin = {
         name => 'Franklin',
-        type => 'cat',
+        type => 'dog',
+        is_good => 1, # All dogs are good
+        num_legs => 4,
+        equipment => ['blanket', 'collar'],
     };
 
     my $new_backend = Yancy::Backend::Test->new( undef, $new_schema );
@@ -99,6 +114,8 @@ subtest 'non-default backend' => sub {
       ->or( sub { diag explain shift->tx->res->json } )
       ->get_ok( '/pets/editor/api/pets/' . $ted->{id} )->status_is( 200 )
       ->json_is( $ted )
+      ->get_ok( '/pets/editor/api/pets/' . $franklin->{id} )->status_is( 200 )
+      ->json_is( $franklin )
       ->or( sub { diag explain shift->tx->res->json } )
       ;
 };


### PR DESCRIPTION
Improve the descriptions' correctness: the behaviour about "*" is only for strings, but numbers and integers do an equal match and booleans do true/false.

Also recognize the string "false" in query so that you can do `value=false`.

Implements queries in OpenAPI endpoints for array parameters, based on array membership.

TODO https://github.com/preaction/Yancy/issues/74 about switching to OpenAPI v3 and adding a `{type: 'object'}` test to `t/plugin/editor.t` which currently gets rejected by JSON::Validator.