### PR TITLE
use utf8 in POD, because contributor names

### DIFF
--- a/lib/Yancy.pm
+++ b/lib/Yancy.pm
@@ -2,6 +2,8 @@ package Yancy;
 our $VERSION = '1.061';
 # ABSTRACT: The Best Web Framework Deserves the Best CMS
 
+=encoding utf8
+
 =head1 SYNOPSIS
 
     use Mojolicious::Lite;


### PR DESCRIPTION
The following error is visible on metacpan in the documentation-view

```
1 POD Error

The following errors were encountered while parsing the POD:

Around line 426:

    Non-ASCII character seen before =encoding in 'Bażant'. Assuming UTF-8
```

force utf8 encoding should fix this.

adding test is not that simple, because contributor list seems to be generated and is not in the source file