### PR TITLE
fix cookbook link to limited-editor example

### DIFF
--- a/lib/Yancy/Help/Cookbook.pod
+++ b/lib/Yancy/Help/Cookbook.pod
@@ -29,5 +29,5 @@ exact schemas and fields you want to allow.
         },
     } );
 
-See L<https://github.com/preaction/Yancy/tree/master/eg/limited-editor>
+See L<https://github.com/preaction/Yancy/tree/master/eg/limited-editor> for the
 complete example.

--- a/lib/Yancy/Help/Cookbook.pod
+++ b/lib/Yancy/Help/Cookbook.pod
@@ -29,5 +29,5 @@ exact schemas and fields you want to allow.
         },
     } );
 
-See L<https://github.com/preaction/Yancy/tree/eg/limited-editor> for the
+See L<https://github.com/preaction/Yancy/tree/master/eg/limited-editor>
 complete example.


### PR DESCRIPTION
Fixes broken link in Cookbook.pod