### PR TITLE
Avoid setting session cookie until actual login

### DIFF
--- a/lib/Yancy/Plugin/Auth/Password.pm
+++ b/lib/Yancy/Plugin/Auth/Password.pm
@@ -535,7 +535,9 @@ sub _get_id_for_username {
 sub current_user {
     my ( $self, $c ) = @_;
     return undef unless my $session = $c->session;
-    my $username = $session->{yancy}{auth}{password} or return undef;
+    my $yancy    = $session->{yancy} or return undef;
+    my $auth     = $yancy->{auth}    or return undef;
+    my $username = $auth->{password} or return undef;
     my $user = $self->_get_user( $c, $username );
     delete $user->{ $self->password_field };
     return $user;


### PR DESCRIPTION
The autovivification of $c->session->{yancy}{auth}{password} sets a cookie for each visitor, even when not using login.
This avoids setting a cookie when just testing for current_user.
(Goes better with a cookie policy, where the user is notified about cookies on the login page)