### PR TITLE
Correct references to Guides::Schema, formerly Help::Config

### DIFF
--- a/lib/Mojolicious/Plugin/Yancy.pm
+++ b/lib/Mojolicious/Plugin/Yancy.pm
@@ -18,7 +18,7 @@ quickly build your own application.
 =head1 CONFIGURATION
 
 For getting started with a configuration for Yancy, see
-L<Yancy::Help::Config>.
+the L<"Yancy Guides"|Yancy::Guides>.
 
 Additional configuration keys accepted by the plugin are:
 
@@ -27,7 +27,7 @@ Additional configuration keys accepted by the plugin are:
 =item backend
 
 In addition to specifying the backend as a single URL (see L<"Database
-Backend"|Yancy::Help::Config/Database Backend>), you can specify it as
+Backend"|Yancy::Guides::Schema/Database Backend>), you can specify it as
 a hashref of C<< class => $db >>. This allows you to share database
 connections.
 

--- a/lib/Yancy/Controller/Yancy.pm
+++ b/lib/Yancy/Controller/Yancy.pm
@@ -158,8 +158,8 @@ for configuration:
 An array reference of columns to display in the table. The same as
 C<x-list-columns> in the schema configuration. Defaults to
 C<x-list-columns> in the schema configuration or all of the schema's
-columns in C<x-order> order. See L<Yancy::Help::Config/Extended
-Collection Configuration> for more information.
+columns in C<x-order> order. See L<Yancy::Guides::Schema/Documenting
+Your Schema> for more information.
 
 =item table
 
@@ -487,8 +487,8 @@ This route creates a new item or updates an existing item in
 a schema. If the user is making a C<GET> request, they will simply
 be shown the template. If the user is making a C<POST> or C<PUT>
 request, the form parameters will be read, the data will be validated
-against L<the schema configuration|Yancy::Help::Config/Data
-Schema>, and the user will either be shown the form again with the
+against L<the schema configuration|Yancy::Guides::Schema>, 
+and the user will either be shown the form again with the
 result of the form submission (success or failure) or the user will be
 forwarded to another place.
 

--- a/lib/Yancy/Controller/Yancy/MultiTenant.pm
+++ b/lib/Yancy/Controller/Yancy/MultiTenant.pm
@@ -202,8 +202,8 @@ This route creates a new item or updates an existing item in
 a schema. If the user is making a C<GET> request, they will simply
 be shown the template. If the user is making a C<POST> or C<PUT>
 request, the form parameters will be read, the data will be validated
-against L<the schema configuration|Yancy::Help::Config/Data
-Collections>, and the user will either be shown the form again with the
+against L<the schema configuration|Yancy::Guides::Schema>,
+and the user will either be shown the form again with the
 result of the form submission (success or failure) or the user will be
 forwarded to another place.
 

--- a/lib/Yancy/Guides/Tutorial.pod
+++ b/lib/Yancy/Guides/Tutorial.pod
@@ -67,7 +67,7 @@ Yancy also accepts a L<JSON Schema|http://json-schema.org> to add more
 information about your data. You can add descriptions, examples, and
 other documentation that will appear in the admin application. You can
 also add type, format, and other validation information, which Yancy
-will use to validate input from users. See L<Yancy::Help::Config/Schema>
+will use to validate input from users. See L<Yancy::Guides::Schema>
 for how to define your schema.
 
     plugin Yancy => backend => 'postgres://postgres@/test',

--- a/lib/Yancy/Plugin/Editor.pm
+++ b/lib/Yancy/Plugin/Editor.pm
@@ -50,8 +50,7 @@ from the backend.
 =head2 openapi
 
 Instead of L</schema>, you can pass a full OpenAPI spec to this editor.
-See L<Yancy::Help::Config> for more details on how to build the OpenAPI
-spec.
+This is deprecated; see L<Yancy::Guides::Upgrading>.
 
 =head2 default_controller
 
@@ -176,7 +175,7 @@ or L<filing a bug report or feature request|https://github.com/preaction/Yancy/i
 
 =head1 SEE ALSO
 
-L<Yancy::Help::Config>, L<Mojolicious::Plugin::Yancy>, L<Yancy>
+L<Yancy::Guides::Schema>, L<Mojolicious::Plugin::Yancy>, L<Yancy>
 
 =cut
 

--- a/lib/Yancy/Plugin/Form.pm
+++ b/lib/Yancy/Plugin/Form.pm
@@ -62,7 +62,7 @@ C<%args> is a list of name/value pairs with the following keys:
 =item type
 
 The type of the input field to create. One of the JSON schema types.
-See L<Yancy::Help::Config/Data Collections> for details on the supported
+See L<Yancy::Guides::Schema/Types> for details on the supported
 types.
 
 =item name
@@ -78,7 +78,7 @@ the current request parameters.
 
 For C<string> types, the format the string should take. One of the
 supported JSON schema formats, along with some additional ones. See
-L<Yancy::Help::Config/Generated Forms> for details on the supported
+L<Yancy::Guides::Schema/Types> for details on the supported
 formats.
 
 =item pattern
@@ -130,7 +130,7 @@ form.
 =back
 
 Most of these properties are the same as the JSON schema field
-properties. See L<Yancy::Help::Config/Generated Forms> for details on
+properties. See L<Yancy::Guides::Schema/Declaring a Schema> for details on
 how Yancy translates JSON schema into forms.
 
 =head2 yancy->form->input_for
@@ -200,12 +200,12 @@ is a hash with the following keys:
 =item title
 
 The field's title. Defaults to the C<title> defined for this property
-in the schema (see L<Yancy::Help::Config>), or the field's name.
+in the schema (see L<Yancy::Guides::Schema>), or the field's name.
 
 =item description
 
 The field's description. Optional. Defaults to the C<description> defined
-for this property in the schema (see L<Yancy::Help::Config>).
+for this property in the schema (see L<Yancy::Guides::Schema>).
 
 =item class
 

--- a/lib/Yancy/Util.pm
+++ b/lib/Yancy/Util.pm
@@ -67,7 +67,7 @@ The C<$db_object> can be one of: L<Mojo::Pg>, L<Mojo::mysql>,
 L<Mojo::SQLite>, or a subclass of L<DBIx::Class::Schema>. The
 appropriate backend object will be created.
 
-See L<Yancy::Help::Config/Database Backend> for information about
+See L<Yancy::Guides::Schema/Database Backend> for information about
 backend URLs and L<Yancy::Backend> for more information about backend
 objects.
 


### PR DESCRIPTION
Help::Config was removed in commit 254d63a, leaving these as broken links since.  Perhaps a more complete explanation in Yancy::Plugin::Editor about the alternatives to OpenAPI specification could be included, or that heading omitted entirely.