### PR TITLE
ignoring column defaults of db which are function calls issue #124

### DIFF
--- a/lib/Yancy/Backend/Dbic.pm
+++ b/lib/Yancy/Backend/Dbic.pm
@@ -305,6 +305,10 @@ sub read_schema {
             my $default = ref $c->{default_value} eq 'SCALAR'
                 ? ${ $c->{default_value} }
                 : $c->{default_value };
+                # if the column default is a function and does not exists in fix_default zap it.
+            if ( $default =~ m#[\w]+\s*\(.*\)# && ! exists $fix_default{$default} ) {
+              $default = undef;
+            }
             $schema{ $schema_name }{ properties }{ $column } = {
                 $self->_map_type( $c ),
                 $is_auto ? ( readOnly => true ) : (),

--- a/lib/Yancy/Backend/Dbic.pm
+++ b/lib/Yancy/Backend/Dbic.pm
@@ -306,7 +306,7 @@ sub read_schema {
                 ? ${ $c->{default_value} }
                 : $c->{default_value };
                 # if the column default is a function and does not exists in fix_default zap it.
-            if ( $default =~ m#[\w]+\s*\(.*\)# && ! exists $fix_default{$default} ) {
+            if ( $default && $default =~ m#[\w]+\s*\(.*\)# && ! exists $fix_default{$default} ) {
               $default = undef;
             }
             $schema{ $schema_name }{ properties }{ $column } = {


### PR DESCRIPTION
currently read_schema returns the default values of db in verbatim even if they are function calls. This causes attempts to insert the function call body as defaults in columns instead of the the value, which does not makes sense. The current fix returns undef for such column defaults. Additionally as a measure of caution it does not do the above in case the default has been handled in fix_default mapping.